### PR TITLE
Cli refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cargo install crucible-fuzz-cli
 crucible init <program_name>
 ```
 
+Defaults to `fuzz/<program_name>/`; pass `-C <dir>` to create or use a harness somewhere else.
+
 ### Run a fuzz test
 
 ```bash

--- a/crates/crucible-fuzz-cli/src/main.rs
+++ b/crates/crucible-fuzz-cli/src/main.rs
@@ -1,7 +1,10 @@
-use std::env::{self, current_dir};
+mod templates;
+use templates::{generate_cargo_toml, generate_harness, generate_idl_readme};
+
+use std::env::current_dir;
 use std::fs::{self, create_dir_all};
 use std::path::{Path, PathBuf};
-use std::process::{exit, Command, ExitStatus, Stdio};
+use std::process::{Command, ExitStatus, Stdio};
 
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
@@ -14,9 +17,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Parser)]
 #[command(name = "crucible", about = "Solana smart contract fuzzing framework")]
 struct Cli {
-    /// Specify location of fuzz dir
-    #[arg(short = 'C', long = "fuzz-dir", global = true)]
-    fuzz_dir: Option<PathBuf>,
+    /// Use this directory instead of ./fuzz/<program_name>/
+    #[arg(short = 'C', long = "harness-dir", global = true)]
+    harness_dir: Option<PathBuf>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -40,7 +43,7 @@ enum Commands {
         /// Build in release mode
         #[arg(long)]
         release: bool,
-        /// Enable LCOV coverage output (single-core only)
+        /// Enable coverage reporting (single-core only)
         #[arg(long)]
         coverage: bool,
         /// Stop after N seconds
@@ -85,7 +88,7 @@ enum Commands {
         /// State pool capacity in stateful mode (default: 256000)
         #[arg(long)]
         pool_size: Option<u64>,
-        /// Path to alternative program .so binary (for coverage with debug builds)
+        /// Path to alternative program .so binary
         #[arg(long)]
         program_so: Option<PathBuf>,
         /// Path to debug binary with DWARF symbols (for source-level coverage with --coverage)
@@ -105,6 +108,9 @@ enum Commands {
     List {
         /// Program name (omit to list all)
         program_name: Option<String>,
+        /// Use this directory instead of ./fuzz/<program_name>/
+        #[arg(short = 'C', long = "harness-dir")]
+        harness_dir: Option<PathBuf>,
     },
     /// View/replay crashes
     Show {
@@ -185,13 +191,10 @@ struct ActionRecord {
 // ============================================================================
 
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    eprintln!("{:?}", args);
-
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Init { program_name } => fuzz_init(&program_name, &cli.fuzz_dir),
+        Commands::Init { program_name } => fuzz_init(&program_name, &cli.harness_dir),
         Commands::Run {
             program_name,
             test_name,
@@ -221,7 +224,7 @@ fn main() -> Result<()> {
             &program_name,
             &test_name,
             binary_in,
-            &cli.fuzz_dir,
+            &cli.harness_dir,
             release,
             coverage,
             timeout,
@@ -243,7 +246,10 @@ fn main() -> Result<()> {
             mode,
             lcov_out,
         ),
-        Commands::List { program_name } => fuzz_list(program_name.as_deref()),
+        Commands::List {
+            program_name,
+            harness_dir,
+        } => fuzz_list(program_name.as_deref(), &harness_dir.or(cli.harness_dir)),
         Commands::Show {
             program_name,
             crash_file,
@@ -252,6 +258,7 @@ fn main() -> Result<()> {
             crashes_dir,
         } => fuzz_show(
             &program_name,
+            &cli.harness_dir,
             crash_file.as_deref(),
             replay,
             regen,
@@ -266,7 +273,7 @@ fn main() -> Result<()> {
         } => fuzz_tmin(
             &program_name,
             &test_name,
-            &cli.fuzz_dir,
+            &cli.harness_dir,
             crash_file.as_deref(),
             all,
             release,
@@ -288,7 +295,7 @@ fn main() -> Result<()> {
             fuzz_cmin(
                 &program_name,
                 &test_name,
-                &cli.fuzz_dir,
+                &cli.harness_dir,
                 input,
                 corpus_out.as_deref(),
                 release,
@@ -301,22 +308,32 @@ fn main() -> Result<()> {
 // Init Command
 // ============================================================================
 
-fn fuzz_init(program_name: &str, fuzz_dir: &Option<PathBuf>) -> Result<()> {
+fn fuzz_init(program_name: &str, harness_dir: &Option<PathBuf>) -> Result<()> {
     let cwd = current_dir()?;
-    let fuzz_dir = fuzz_dir.clone().unwrap_or(cwd.join("fuzz"));
 
-    // Create fuzz/ directory and .gitignore
-    if !fuzz_dir.exists() {
-        create_dir_all(&fuzz_dir)?;
-        fs::write(
-            fuzz_dir.join(".gitignore"),
-            "*/target/\n*/crashes/\n.fuzz-cache/\n",
-        )
-        .context("Failed to create .gitignore")?;
-    }
+    // If --harness-dir is given, use it directly as the harness root.
+    // Otherwise create ./fuzz/<program_name>/.
+    let fuzz_program_path = if let Some(dir) = harness_dir {
+        let dir = if dir.is_absolute() {
+            dir.clone()
+        } else {
+            cwd.join(dir)
+        };
+        dir
+    } else {
+        let fuzz_dir = cwd.join("fuzz");
+        // Create fuzz/ directory and .gitignore
+        if !fuzz_dir.exists() {
+            create_dir_all(&fuzz_dir)?;
+            fs::write(
+                fuzz_dir.join(".gitignore"),
+                "*/target/\n*/crashes/\n.fuzz-cache/\n",
+            )
+            .context("Failed to create .gitignore")?;
+        }
+        fuzz_dir.join(program_name)
+    };
 
-    // Create standalone fuzz package
-    let fuzz_program_path = fuzz_dir.join(program_name);
     if fuzz_program_path.exists() {
         bail!("{} already exists", fuzz_program_path.display());
     }
@@ -348,11 +365,12 @@ fn fuzz_init(program_name: &str, fuzz_dir: &Option<PathBuf>) -> Result<()> {
     )
     .context("Failed to write IDL README")?;
 
-    println!("\nCreated fuzz harness at: fuzz/{}/", program_name);
+    let harness_display = fuzz_program_path.display();
+    println!("\nCreated fuzz harness at: {}/", harness_display);
     println!("\nNext steps:");
     println!(
-        "  1. Copy your IDL to: fuzz/{}/idls/{}.json",
-        program_name, program_name
+        "  1. Copy your IDL to: {}/idls/{}.json",
+        harness_display, program_name
     );
     println!("     (Run `anchor idl convert` if using legacy IDL format)");
     println!(
@@ -360,8 +378,8 @@ fn fuzz_init(program_name: &str, fuzz_dir: &Option<PathBuf>) -> Result<()> {
         program_name
     );
     println!(
-        "  3. Implement action_* methods in: fuzz/{}/src/main.rs",
-        program_name
+        "  3. Implement action_* methods in: {}/src/main.rs",
+        harness_display
     );
     println!(
         "  4. Run: crucible run {} invariant_test --release",
@@ -369,148 +387,6 @@ fn fuzz_init(program_name: &str, fuzz_dir: &Option<PathBuf>) -> Result<()> {
     );
 
     Ok(())
-}
-
-fn generate_cargo_toml(program_name: &str) -> String {
-    let repo = "https://github.com/asymmetric-research/crucible";
-    let branch = "main";
-
-    format!(
-        r#"[package]
-name = "{program_name}_fuzz"
-version = "0.1.0"
-edition = "2021"
-
-[workspace]
-# Standalone workspace - isolated from parent project to avoid Solana version conflicts
-
-[dependencies]
-# Fuzzing framework
-crucible-fuzzer = {{ git = "{repo}", branch = "{branch}" }}
-crucible-test-context = {{ git = "{repo}", branch = "{branch}" }}
-crucible-idl-gen = {{ git = "{repo}", branch = "{branch}" }}
-
-# Anchor (v3-compatible fork with solana-sysvar ~3.1 fix)
-anchor-lang = {{ git = "https://github.com/asymmetric-research/anchor-fuzzing", branch = "feature/fuzzing" }}
-
-# Solana v3.x (required for litesvm 0.9.0)
-solana-pubkey = "3.0"
-solana-keypair = "3.1"
-solana-signer = "3.0"
-solana-program = "3.0"
-solana-message = "3.0"
-solana-signature = "3.1"
-solana-instruction = "3.1"
-
-# Fuzzing
-libafl = {{ version = "0.15.1", features = ["std", "cli", "prelude"] }}
-libafl_bolts = {{ version = "0.15.1", features = ["std"] }}
-arbitrary = {{ version = "1", features = ["derive"] }}
-
-# Utilities
-anyhow = "1.0"
-bytemuck = "1.14"
-ctor = "0.6"
-
-[features]
-invariant_test = []
-"#
-    )
-}
-
-fn generate_harness(program_name: &str) -> String {
-    let fixture_name = to_pascal_case(program_name);
-    format!(
-        r#"use crucible_fuzzer::*;
-use anchor_lang::prelude::*;
-use solana_keypair::Keypair;
-use solana_signer::Signer;
-use solana_pubkey::Pubkey;
-use anchor_lang::system_program;
-use std::rc::Rc;
-
-// Generate types from IDL (no crate dependency - avoids version conflicts)
-crucible_idl_gen::declare_fuzz_program!("idls/{program_name}.json");
-
-use {program_name}::instruction;
-use {program_name}::accounts;
-
-#[derive(Clone)]
-struct {fixture_name} {{
-    ctx: TestContext,
-    program_id: Pubkey,
-    admin: Rc<Keypair>,
-    // TODO: Add your state here (users, accounts, etc.)
-}}
-
-#[fuzz_fixture]
-impl {fixture_name} {{
-    /// Called ONCE to setup initial state (programs + accounts)
-    pub fn setup() -> Self {{
-        let mut ctx = TestContext::new();
-        let program_id = {program_name}::ID;
-
-        // Load program binary (built separately from fuzz harness)
-        ctx.add_program(&program_id, "../../target/deploy/{program_name}.so").unwrap();
-
-        // Create admin account
-        let admin = Rc::new(Keypair::new());
-        ctx.create_account()
-            .pubkey(admin.pubkey())
-            .lamports(100_000_000_000)
-            .owner(system_program::ID)
-            .create()
-            .unwrap();
-
-        // TODO: Initialize your program state here
-
-        Self {{ ctx, program_id, admin }}
-    }}
-
-    /// ACTIONS - Define actions that the fuzzer can call
-    pub fn action_noop(&mut self) {{
-        // Placeholder - replace with real actions
-    }}
-
-    // TODO: Add your actions here
-}}
-
-#[invariant_test]
-fn invariant_test(fixture: &mut {fixture_name}) {{
-    // TODO: Add invariant checks that should hold after every action
-}}
-"#,
-    )
-}
-
-fn generate_idl_readme(program_name: &str) -> String {
-    format!(
-        r#"# IDL Files
-
-Place your program's IDL JSON file here as `{program_name}.json`.
-
-## Generating IDL
-
-If you have the legacy (v0.29) IDL format:
-```bash
-anchor idl convert target/idl/{program_name}.json -o fuzz/{program_name}/idls/{program_name}.json
-```
-
-If you have the new IDL format (v0.30+), copy it directly.
-"#
-    )
-}
-
-fn to_pascal_case(s: &str) -> String {
-    s.split(|c: char| c == '_' || c == '-')
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
-            }
-        })
-        .collect()
 }
 
 // ============================================================================
@@ -535,7 +411,7 @@ fn fuzz_run(
     program_name: &str,
     test_name: &str,
     binary_in: Option<PathBuf>,
-    fuzz_dir: &Option<PathBuf>,
+    harness_dir: &Option<PathBuf>,
     release: bool,
     coverage: bool,
     timeout: Option<u64>,
@@ -557,7 +433,10 @@ fn fuzz_run(
     mode: Option<String>,
     lcov_out: Option<PathBuf>,
 ) -> Result<()> {
-    // Translate --mode into equivalent existing flags
+    let remote = mode.is_some();
+
+    // Translate --mode into equivalent flags.
+    // All path defaults are relative to cwd (the remote driver's working directory).
     let mut coverage = coverage;
     let mut corpus_in = corpus_in;
     let mut corpus_out = corpus_out;
@@ -574,6 +453,9 @@ fn fuzz_run(
             "explore" => {
                 if corpus_out.is_none() {
                     corpus_out = Some("./corpus".into());
+                }
+                if corpus_in.is_none() {
+                    corpus_in = Some("./corpus".into());
                 }
                 if crashes_out.is_none() {
                     crashes_out = Some("./output".into());
@@ -592,8 +474,7 @@ fn fuzz_run(
                 }
             }
             "corpus_merge" => {
-                // Remote fuzzing corpus_merge: read from ./corpus, write minimized corpus to ./output
-                // Delegates to the cmin (greedy set-cover) codepath via FUZZ_CMIN env var
+                // Read from ./corpus, write minimized corpus to ./output via FUZZ_CMIN
                 if corpus_in.is_none() {
                     corpus_in = Some("./corpus".into());
                 }
@@ -608,7 +489,7 @@ fn fuzz_run(
     }
 
     let cwd = current_dir()?;
-    let fuzz_dir = resolve_fuzz_dir(&fuzz_dir.clone().unwrap_or(cwd.clone()), program_name)?;
+    let fuzz_dir = resolve_fuzz_dir(&harness_dir.clone().unwrap_or(cwd.clone()), program_name)?;
 
     let mut cmd = if let Some(binary_path) = binary_in {
         let binary_path = resolve_path(&cwd, &binary_path);
@@ -620,35 +501,21 @@ fn fuzz_run(
         cmd.current_dir(&fuzz_dir);
         cmd
     } else {
-        // Build if cargo is available, then run the binary directly
         try_cargo_build(&fuzz_dir, release, test_name)?;
-
         let profile = if release { "release" } else { "debug" };
-        let binary_path = find_fuzz_binary(&fuzz_dir, program_name, profile)?;
-
+        let binary_path = find_fuzz_binary(&fuzz_dir, profile)?;
         let mut cmd = Command::new(&binary_path);
         cmd.current_dir(&fuzz_dir);
         cmd
     };
-
-    if coverage {
-        cmd.env("FUZZ_COVERAGE", "1");
-        cmd.env(
-            "FUZZ_CORPUS_IN",
-            resolve_path(
-                &cwd,
-                &corpus_in.clone().expect("Need corpus in for coverage"),
-            )
-            .to_str()
-            .unwrap(),
-        );
-    }
 
     if let Some(timeout_secs) = timeout {
         cmd.env("FUZZ_TIMEOUT_SECS", timeout_secs.to_string());
         println!("[FUZZ] Running with {}s timeout", timeout_secs);
     }
 
+    // corpus_in: always pass if non-empty; in remote mode also pass if dir doesn't exist yet
+    // (the remote driver may populate it after the CLI check).
     if let Some(ref corpus_in_path) = corpus_in {
         let abs_path = resolve_path(&cwd, corpus_in_path);
         let has_inputs = abs_path.exists()
@@ -658,9 +525,7 @@ fn fuzz_run(
         if has_inputs {
             cmd.env("FUZZ_CORPUS_IN", &abs_path);
             println!("[FUZZ] Loading corpus from: {}", corpus_in_path.display());
-        } else if mode.is_some() {
-            // In remote --mode, always pass FUZZ_CORPUS_IN — the dir may be
-            // populated by the remote driver after the CLI checks it.
+        } else if remote {
             cmd.env("FUZZ_CORPUS_IN", &abs_path);
             println!(
                 "[FUZZ] Corpus directory passed to harness: {}",
@@ -681,18 +546,19 @@ fn fuzz_run(
 
     if let Some(ref corpus_out_path) = corpus_out {
         let abs_path = resolve_path(&cwd, corpus_out_path);
-        cmd.env("FUZZ_CORPUS_OUT", abs_path);
+        cmd.env("FUZZ_CORPUS_OUT", &abs_path);
         println!("[FUZZ] Writing corpus to: {}", corpus_out_path.display());
     }
 
-    if mode.as_deref() == Some("explore") {
-        assert!(corpus_out.is_some());
-    }
-
+    // crashes_out defaults:
+    //   remote mode → ./output  (already set above per-mode)
+    //   local       → ./crashes/<test_name>
     let crashes_abs_path = if let Some(ref crashes_path) = crashes_out {
         resolve_path(&cwd, crashes_path)
+    } else if remote {
+        fuzz_dir.join("crashes")
     } else {
-        fuzz_dir.join("output").join(test_name)
+        fuzz_dir.join("crashes").join(test_name)
     };
     cmd.env("FUZZ_CRASHES_DIR", &crashes_abs_path);
     println!("[FUZZ] Crashes directory: {}", crashes_abs_path.display());
@@ -703,13 +569,8 @@ fn fuzz_run(
             abs_path
         } else {
             // Search crashes directory for this crash name
-            let crashes_search_root = if let Some(ref cp) = crashes_out {
-                resolve_path(&cwd, cp)
-            } else {
-                fuzz_dir.join("output")
-            };
             match find_crash_file(
-                &crashes_search_root,
+                &crashes_abs_path,
                 program_name,
                 &replay_path.to_string_lossy(),
             ) {
@@ -761,81 +622,67 @@ fn fuzz_run(
         println!("[FUZZ] State pool size: {}", size);
     }
 
-    // --program-so: CLI flag takes priority, then fall back to env var (remote --mode)
     if let Some(ref program_so_path) = program_so {
         let abs_path = resolve_path(&cwd, program_so_path);
         cmd.env("FUZZ_PROGRAM_SO", &abs_path);
         println!("[FUZZ] Program binary override: {}", abs_path.display());
-    } else if mode.is_some() {
-        if let Ok(env_val) = env::var("FUZZ_PROGRAM_SO") {
-            let abs_path = resolve_path(&cwd, &PathBuf::from(&env_val));
-            cmd.env("FUZZ_PROGRAM_SO", &abs_path);
-            println!("[FUZZ] Program binary override (env): {}", abs_path.display());
-        }
     }
 
-    // --symbols: CLI flag takes priority, then fall back to env var (remote --mode)
     if let Some(ref symbols_path) = symbols {
         let abs_path = resolve_path(&cwd, symbols_path);
-        let canonical = abs_path.canonicalize().unwrap_or(abs_path);
+        let canonical = abs_path
+            .canonicalize()
+            .context("Debug symbols file not found")?;
         cmd.env("FUZZ_SYMBOLS", &canonical);
         println!("[FUZZ] Debug symbols: {}", canonical.display());
-    } else if mode.is_some() {
-        if let Ok(env_val) = env::var("FUZZ_SYMBOLS") {
-            let abs_path = resolve_path(&cwd, &PathBuf::from(&env_val));
-            let canonical = abs_path.canonicalize().unwrap_or(abs_path);
-            cmd.env("FUZZ_SYMBOLS", &canonical);
-            println!("[FUZZ] Debug symbols (env): {}", canonical.display());
-        }
     }
 
-    // Default: 8 for stateless (mutation cap), 100 for stateful (deeper exploration).
-    // Replay/corpus-in always executes full sequences (uncapped in invariant macro).
+    // Default: 8 for stateless, 100 for stateful.
     let max_actions = max_actions.unwrap_or(if stateful { 100 } else { 8 });
     cmd.env("FUZZ_MAX_ACTIONS", max_actions.to_string());
     println!("[FUZZ] Max actions per iteration: {}", max_actions);
 
     if mode.as_deref() == Some("corpus_merge") {
-        // corpus_merge uses the cmin (greedy set-cover) codepath to write minimized corpus
         cmd.env("FUZZ_CMIN", "1");
-        println!("[FUZZ] Corpus merge mode: minimizing corpus to ./corpus");
-    } else if coverage && corpus_in.is_some() && timeout.is_none() && !dry_run && replay.is_none() {
-        cmd.env("FUZZ_COVERAGE_ONLY", "1");
-        cmd.env(
-            "FUZZ_CORPUS_IN",
-            resolve_path(
-                &cwd,
-                &corpus_in.clone().expect("Need corpus in for coverage"),
-            )
-            .to_str()
-            .unwrap(),
-        );
-        println!("[FUZZ] Coverage-only mode: generating coverage from corpus");
+        println!("[FUZZ] Corpus merge mode: minimizing corpus");
+    } else if coverage {
+        let corpus_in_abs = corpus_in
+            .as_ref()
+            .map(|p| resolve_path(&cwd, p))
+            .ok_or_else(|| anyhow::anyhow!("--coverage requires --corpus-in"))?;
+        cmd.env("FUZZ_COVERAGE", "1");
+        cmd.env("FUZZ_CORPUS_IN", &corpus_in_abs);
+        // coverage-only (no fuzzing) when no timeout/dry-run/replay override
+        if timeout.is_none() && !dry_run && replay.is_none() {
+            cmd.env("FUZZ_COVERAGE_ONLY", "1");
+            println!("[FUZZ] Coverage-only mode: generating coverage from corpus");
+        }
     }
 
-    // Set LCOV coverage output path
-    if let Some(ref lcov_out_path) = lcov_out {
-        let abs_path = resolve_path(&cwd, lcov_out_path);
-        cmd.env("FUZZ_COVERAGE_OUT", &abs_path);
-        println!("[FUZZ] LCOV output: {}", abs_path.display());
-    } else if mode.as_deref() == Some("coverage") {
-        // Default coverage output for coverage mode
-        let output_dir = resolve_path(&cwd, &PathBuf::from("./output"));
-        let _ = fs::create_dir_all(&output_dir);
-        let lcov_path = output_dir.join("coverage.lcov");
+    // LCOV output path:
+    //   explicit --lcov-out  → that path
+    //   remote coverage mode → ./output/coverage.lcov
+    //   local coverage       → ./coverage/coverage.lcov
+    if coverage || lcov_out.is_some() {
+        let lcov_path = if let Some(ref p) = lcov_out {
+            resolve_path(&cwd, p)
+        } else if remote {
+            let dir = resolve_path(&cwd, &PathBuf::from("./output"));
+            let _ = fs::create_dir_all(&dir);
+            dir.join("coverage.lcov")
+        } else {
+            let dir = resolve_path(&cwd, &PathBuf::from("./coverage"));
+            let _ = fs::create_dir_all(&dir);
+            dir.join("coverage.lcov")
+        };
         cmd.env("FUZZ_COVERAGE_OUT", &lcov_path);
         println!("[FUZZ] LCOV output: {}", lcov_path.display());
     }
 
-    eprintln!("Debug env: {:?}", cmd.get_envs());
-    eprintln!("Debug pwd: {:?}", cmd.get_current_dir());
-
     let status = cmd.status().context("Failed to run fuzz binary")?;
     if !status.success() {
         // In reproduce mode, exit code 1 means crash reproduced (not a failure).
-        // The remote driver uses the "did not reproduce" string on stdout, not exit code.
         if mode.as_deref() == Some("reproduce") {
-            // Pass through the exit code without treating it as an error
             std::process::exit(status.code().unwrap_or(1));
         }
         match status.code() {
@@ -851,23 +698,30 @@ fn fuzz_run(
 // List Command
 // ============================================================================
 
-fn fuzz_list(program_name: Option<&str>) -> Result<()> {
+fn fuzz_list(program_name: Option<&str>, harness_dir: &Option<PathBuf>) -> Result<()> {
     let cwd = current_dir()?;
-    let fuzz_root = cwd.join("fuzz");
 
     match program_name {
         Some(name) => {
-            let fuzz_dir = fuzz_root.join(name);
-            if !fuzz_dir.exists() {
-                bail!(
-                    "Fuzz directory for {} does not exist. Run `crucible init {}` first.",
-                    name,
-                    name
-                );
-            }
+            let fuzz_dir = resolve_fuzz_dir(&harness_dir.clone().unwrap_or(cwd.clone()), name)?;
             list_program_tests(&fuzz_dir, name)?;
         }
         None => {
+            // If a harness_dir is given, list just that one harness.
+            if let Some(dir) = harness_dir {
+                let dir = if dir.is_absolute() {
+                    dir.clone()
+                } else {
+                    cwd.join(dir)
+                };
+                let name = dir
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown");
+                return list_program_tests(&dir, name);
+            }
+
+            let fuzz_root = cwd.join("fuzz");
             if !fuzz_root.exists() {
                 println!("No fuzz/ directory found. Run `crucible init <program>` to create one.");
                 return Ok(());
@@ -952,6 +806,7 @@ fn list_program_tests(fuzz_dir: &Path, program_name: &str) -> Result<()> {
 
 fn fuzz_show(
     program_name: &str,
+    harness_dir: &Option<PathBuf>,
     crash_file: Option<&str>,
     replay: bool,
     regen: bool,
@@ -978,7 +833,7 @@ fn fuzz_show(
             bail!("Cannot auto-detect fuzz harness. Run from within fuzz harness directory or specify program name.");
         }
     } else {
-        let fuzz_dir = resolve_fuzz_dir(&cwd, program_name)?;
+        let fuzz_dir = resolve_fuzz_dir(&harness_dir.clone().unwrap_or(cwd.clone()), program_name)?;
         let display_name = fuzz_dir
             .file_name()
             .and_then(|n| n.to_str())
@@ -988,7 +843,7 @@ fn fuzz_show(
     };
 
     match crash_file {
-        None if replay && regen => regen_crashes(&fuzz_dir, &display_name, custom_crashes_dir),
+        None if replay && regen => regen_crashes(&fuzz_dir, custom_crashes_dir),
         None => list_crashes(&fuzz_dir, &display_name, custom_crashes_dir),
         Some(crash_name) if !replay => {
             show_crash_metadata(&fuzz_dir, &display_name, crash_name, custom_crashes_dir)
@@ -1002,9 +857,7 @@ fn list_crashes(
     program_name: &str,
     custom_crashes_dir: Option<&Path>,
 ) -> Result<()> {
-    let crashes_dir = custom_crashes_dir
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| fuzz_dir.join("crashes"));
+    let crashes_dir = resolve_crashes_dir(fuzz_dir, custom_crashes_dir);
     if !crashes_dir.exists() {
         println!("No crashes directory found at: {}", crashes_dir.display());
         println!("Run the fuzzer first to generate crashes.");
@@ -1219,9 +1072,7 @@ fn show_crash_metadata(
     crash_name: &str,
     custom_crashes_dir: Option<&Path>,
 ) -> Result<()> {
-    let crashes_dir = custom_crashes_dir
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| fuzz_dir.join("crashes"));
+    let crashes_dir = resolve_crashes_dir(fuzz_dir, custom_crashes_dir);
 
     // Search for .meta.json and/or raw crash file
     let mut meta_path = None;
@@ -1371,20 +1222,18 @@ fn replay_crash(
     crash_name: &str,
     custom_crashes_dir: Option<&Path>,
 ) -> Result<()> {
-    let crashes_dir = custom_crashes_dir
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| fuzz_dir.join("crashes"));
+    let crashes_dir = resolve_crashes_dir(fuzz_dir, custom_crashes_dir);
 
     // Check if crash_name is a directory — replay all crashes in it
     let replay_dir = resolve_replay_directory(crash_name, &crashes_dir);
     if let Some(dir) = replay_dir {
-        return replay_crash_directory(fuzz_dir, program_name, &dir);
+        return replay_crash_directory(fuzz_dir, &dir);
     }
 
     // Single crash replay
     let (crash_path, test_name) = find_crash_file(&crashes_dir, program_name, crash_name)?;
 
-    let binary_path = build_and_find_replay_binary(fuzz_dir, program_name, test_name.as_deref())?;
+    let binary_path = build_and_find_replay_binary(fuzz_dir, test_name.as_deref())?;
 
     println!("Replaying crash: {}", crash_path.display());
     println!("Using binary: {}\n", binary_path.display());
@@ -1415,7 +1264,7 @@ fn resolve_replay_directory(crash_name: &str, crashes_dir: &Path) -> Option<Path
 }
 
 /// Replay all crash files in a directory.
-fn replay_crash_directory(fuzz_dir: &Path, program_name: &str, dir: &Path) -> Result<()> {
+fn replay_crash_directory(fuzz_dir: &Path, dir: &Path) -> Result<()> {
     // Collect crash files (skip metadata/hidden)
     let mut crash_files: Vec<(String, PathBuf)> = Vec::new();
     for entry in fs::read_dir(dir)? {
@@ -1444,7 +1293,7 @@ fn replay_crash_directory(fuzz_dir: &Path, program_name: &str, dir: &Path) -> Re
         .and_then(|n| n.to_str())
         .map(|s| s.to_string());
 
-    let binary_path = build_and_find_replay_binary(fuzz_dir, program_name, test_name.as_deref())?;
+    let binary_path = build_and_find_replay_binary(fuzz_dir, test_name.as_deref())?;
 
     println!(
         "[REPLAY] Replaying {} crash(es) from: {}\n",
@@ -1614,11 +1463,7 @@ fn find_crash_file(
 }
 
 /// Build the replay binary and return its path.
-fn build_and_find_replay_binary(
-    fuzz_dir: &Path,
-    program_name: &str,
-    test_feature: Option<&str>,
-) -> Result<PathBuf> {
+fn build_and_find_replay_binary(fuzz_dir: &Path, test_feature: Option<&str>) -> Result<PathBuf> {
     if has_cargo() {
         if let Some(feature) = test_feature {
             if !feature.is_empty() {
@@ -1649,14 +1494,13 @@ fn build_and_find_replay_binary(
         println!("[REPLAY] cargo not found, looking for pre-built binary...");
     }
 
-    find_fuzz_binary(fuzz_dir, program_name, "release")
-        .or_else(|_| find_fuzz_binary(fuzz_dir, program_name, "debug"))
+    find_fuzz_binary(fuzz_dir, "release").or_else(|_| find_fuzz_binary(fuzz_dir, "debug"))
 }
 
 /// Run the replay binary for a single crash file.
 fn run_replay(binary_path: &Path, fuzz_dir: &Path, crash_path: &Path) -> Result<ExitStatus> {
     // Canonicalize crash path so it works regardless of the binary's working directory
-    let abs_crash = crash_path.canonicalize().unwrap_or_else(|_| crash_path.to_path_buf());
+    let abs_crash = crash_path.canonicalize().context("Crash file not found")?;
     Command::new(binary_path)
         .current_dir(fuzz_dir)
         .env("FUZZ_INPUT_FILE", &abs_crash)
@@ -1685,13 +1529,13 @@ fn print_replay_result(status: &ExitStatus) {
 fn fuzz_tmin(
     program_name: &str,
     test_name: &str,
-    fuzz_dir: &Option<PathBuf>,
+    harness_dir: &Option<PathBuf>,
     crash_file: Option<&str>,
     all: bool,
     release: bool,
 ) -> Result<()> {
     let cwd = current_dir()?;
-    let fuzz_dir = resolve_fuzz_dir(&fuzz_dir.clone().unwrap_or(cwd), program_name)?;
+    let fuzz_dir = resolve_fuzz_dir(&harness_dir.clone().unwrap_or(cwd), program_name)?;
 
     // Auto-detect: if test_name looks like a crash ID and no crash_file was given,
     // search all test directories for it. Allows: crucible tmin stake crash_abc123
@@ -1745,11 +1589,10 @@ fn fuzz_tmin(
             let entry = entry?;
             let path = entry.path();
             if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name.ends_with(".meta.json") {
-                    let crash_id = name.strip_suffix(".meta.json").unwrap().to_string();
-                    let binary_path = crashes_dir.join(&crash_id);
+                if let Some(crash_id) = name.strip_suffix(".meta.json") {
+                    let binary_path = crashes_dir.join(crash_id);
                     if binary_path.exists() && binary_path.is_file() {
-                        files.push((crash_id, binary_path));
+                        files.push((crash_id.to_string(), binary_path));
                     }
                 }
             }
@@ -1787,7 +1630,7 @@ fn fuzz_tmin(
     // Build the binary (skipped if cargo not available)
     let profile = if release { "release" } else { "debug" };
     try_cargo_build(&fuzz_dir, release, test_name)?;
-    let binary_path = find_fuzz_binary(&fuzz_dir, program_name, profile)?;
+    let binary_path = find_fuzz_binary(&fuzz_dir, profile)?;
 
     // Minimize crash(es)
     if all {
@@ -1836,14 +1679,8 @@ fn fuzz_tmin(
     Ok(())
 }
 
-fn regen_crashes(
-    fuzz_dir: &Path,
-    program_name: &str,
-    custom_crashes_dir: Option<&Path>,
-) -> Result<()> {
-    let crashes_dir = custom_crashes_dir
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| fuzz_dir.join("crashes"));
+fn regen_crashes(fuzz_dir: &Path, custom_crashes_dir: Option<&Path>) -> Result<()> {
+    let crashes_dir = resolve_crashes_dir(fuzz_dir, custom_crashes_dir);
     if !crashes_dir.exists() {
         bail!(
             "No crashes directory found at: {}\nRun the fuzzer first to generate crashes.",
@@ -1852,8 +1689,8 @@ fn regen_crashes(
     }
 
     // Find the binary (try release then debug)
-    let binary_path = find_fuzz_binary(fuzz_dir, program_name, "release")
-        .or_else(|_| find_fuzz_binary(fuzz_dir, program_name, "debug"))?;
+    let binary_path =
+        find_fuzz_binary(fuzz_dir, "release").or_else(|_| find_fuzz_binary(fuzz_dir, "debug"))?;
 
     // Iterate all test subdirectories in crashes/
     let mut total_ok = 0usize;
@@ -1948,13 +1785,13 @@ fn regen_crashes(
 fn fuzz_cmin(
     program_name: &str,
     test_name: &str,
-    fuzz_dir: &Option<PathBuf>,
+    harness_dir: &Option<PathBuf>,
     corpus_in: &Path,
     corpus_out: Option<&Path>,
     release: bool,
 ) -> Result<()> {
     let cwd = current_dir()?;
-    let fuzz_dir = resolve_fuzz_dir(&fuzz_dir.clone().unwrap_or(cwd.clone()), program_name)?;
+    let fuzz_dir = resolve_fuzz_dir(&harness_dir.clone().unwrap_or(cwd.clone()), program_name)?;
 
     let corpus_in_abs = resolve_path(&cwd, corpus_in);
     if !corpus_in_abs.exists() {
@@ -1988,7 +1825,10 @@ fn fuzz_cmin(
 
     let corpus_out_abs = corpus_out
         .map(|p| resolve_path(&cwd, p))
-        .unwrap_or_else(|| corpus_in_abs.clone());
+        .unwrap_or_else(|| {
+            println!("[CMIN] Merging corpus in place!");
+            corpus_in_abs.clone()
+        });
 
     if corpus_out_abs != corpus_in_abs {
         fs::create_dir_all(&corpus_out_abs)?;
@@ -1997,7 +1837,7 @@ fn fuzz_cmin(
 
     let profile = if release { "release" } else { "debug" };
     try_cargo_build(&fuzz_dir, release, test_name)?;
-    let binary_path = find_fuzz_binary(&fuzz_dir, program_name, profile)?;
+    let binary_path = find_fuzz_binary(&fuzz_dir, profile)?;
 
     println!("[CMIN] Running corpus minimization...");
 
@@ -2025,29 +1865,46 @@ fn fuzz_cmin(
 // Utilities
 // ============================================================================
 
-/// Resolve the fuzz directory for a program name.
-/// Supports running from project root (fuzz/<program>/) or from within a fuzz directory.
+/// Resolve the fuzz harness directory for a program name.
+///
+/// `root` is either:
+/// - the project root (normal case, no --harness-dir): looks under root/fuzz/<program>/
+/// - a custom harness root (--harness-dir): treats root itself as the harness dir if it
+///   contains a Cargo.toml, otherwise looks for root/<program>/ inside it.
+///
 /// Also tries hyphen/underscore conversion and auto-detects if only one harness exists.
-fn resolve_fuzz_dir(cwd: &Path, program_name: &str) -> Result<PathBuf> {
-    // Direct match
-    let fuzz_dir = cwd.join("fuzz").join(program_name);
+fn resolve_fuzz_dir(root: &Path, program_name: &str) -> Result<PathBuf> {
+    // If root itself is a harness dir, use it directly.
+    if root.join("Cargo.toml").exists() && root.join("src").exists() {
+        return Ok(root.to_path_buf());
+    }
+
+    // Try root/fuzz/<program>/ (normal project-root case)
+    let fuzz_dir = root.join("fuzz").join(program_name);
     if fuzz_dir.exists() {
         return Ok(fuzz_dir);
     }
 
-    // Try hyphen <-> underscore conversion
+    // Try root/<program>/ (--harness-dir points to fuzz/ itself)
+    let direct = root.join(program_name);
+    if direct.exists() && direct.join("Cargo.toml").exists() {
+        return Ok(direct);
+    }
+
+    // Try hyphen <-> underscore conversion in both locations
     let alt_name = if program_name.contains('-') {
         program_name.replace('-', "_")
     } else {
         program_name.replace('_', "-")
     };
-    let alt_dir = cwd.join("fuzz").join(&alt_name);
-    if alt_dir.exists() {
-        return Ok(alt_dir);
+    for candidate in [root.join("fuzz").join(&alt_name), root.join(&alt_name)] {
+        if candidate.exists() && candidate.join("Cargo.toml").exists() {
+            return Ok(candidate);
+        }
     }
 
-    // If fuzz/ exists and has exactly one harness, use it
-    let fuzz_root = cwd.join("fuzz");
+    // Auto-detect: if fuzz/ has exactly one harness, use it
+    let fuzz_root = root.join("fuzz");
     if fuzz_root.exists() {
         if let Ok(entries) = fs::read_dir(&fuzz_root) {
             let harnesses: Vec<_> = entries
@@ -2060,30 +1917,11 @@ fn resolve_fuzz_dir(cwd: &Path, program_name: &str) -> Result<PathBuf> {
         }
     }
 
-    // Maybe we're already in the fuzz dir
-    if cwd.join("Cargo.toml").exists() && cwd.join("src").exists() {
-        return Ok(cwd.to_path_buf());
-    }
-
     bail!(
         "Fuzz directory for {} does not exist. Run `crucible init {}` first.",
         program_name,
         program_name
     );
-}
-
-/// Check if a file is executable (unix).
-#[cfg(unix)]
-fn is_executable(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
-    path.metadata()
-        .map(|m| m.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
-}
-
-#[cfg(not(unix))]
-fn is_executable(_path: &Path) -> bool {
-    true
 }
 
 /// Check if cargo is available in PATH.
@@ -2125,6 +1963,13 @@ fn try_cargo_build(fuzz_dir: &Path, release: bool, feature: &str) -> Result<bool
     Ok(true)
 }
 
+/// Resolve the crashes directory: use the custom path if provided, else default to `<fuzz_dir>/crashes`.
+fn resolve_crashes_dir(fuzz_dir: &Path, custom: Option<&Path>) -> PathBuf {
+    custom
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| fuzz_dir.join("crashes"))
+}
+
 /// Convert a potentially relative path to absolute, relative to cwd.
 fn resolve_path(cwd: &Path, path: &Path) -> PathBuf {
     if path.is_absolute() {
@@ -2134,556 +1979,45 @@ fn resolve_path(cwd: &Path, path: &Path) -> PathBuf {
     }
 }
 
-/// Find the fuzz binary by querying cargo metadata.
-/// Given parsed cargo metadata, resolve the fuzz binary path.
-/// `exists_fn` checks whether a candidate path exists on disk.
-fn resolve_binary_from_metadata(
-    metadata: &serde_json::Value,
-    fuzz_dir: &Path,
-    program_name: &str,
-    profile: &str,
-    exists_fn: impl Fn(&Path) -> bool,
-) -> Result<PathBuf> {
-    let target_dir = metadata["target_directory"].as_str().unwrap_or("");
-    if !target_dir.is_empty() {
-        if let Some(packages) = metadata["packages"].as_array() {
-            // Helper: try to find a bin target in a package
-            let try_package = |package: &serde_json::Value| -> Option<PathBuf> {
-                let pkg_name = package["name"].as_str().unwrap_or("");
-                // Check explicit [[bin]] targets first
-                if let Some(targets) = package["targets"].as_array() {
-                    for target in targets {
-                        let kinds = target["kind"].as_array();
-                        let is_bin =
-                            kinds.map_or(false, |k| k.iter().any(|v| v.as_str() == Some("bin")));
-                        if is_bin {
-                            if let Some(bin_name) = target["name"].as_str() {
-                                let binary = PathBuf::from(target_dir).join(profile).join(bin_name);
-                                if exists_fn(&binary) {
-                                    return Some(binary);
-                                }
-                            }
-                        }
-                    }
-                }
-                // Fall back to package name as binary name
-                let binary = PathBuf::from(target_dir).join(profile).join(pkg_name);
-                if exists_fn(&binary) {
-                    return Some(binary);
-                }
-                None
-            };
-
-            // First pass: match by name
-            for package in packages {
-                let pkg_name = package["name"].as_str().unwrap_or("");
-                if pkg_name.contains(program_name)
-                    || pkg_name.contains(&program_name.replace('-', "_"))
-                {
-                    if let Some(path) = try_package(package) {
-                        return Ok(path);
-                    }
-                }
-            }
-
-            // Second pass: if there's exactly one package (standalone workspace),
-            // use it regardless of name — the fuzz_dir already scoped us correctly
-            if packages.len() == 1 {
-                if let Some(path) = try_package(&packages[0]) {
-                    return Ok(path);
-                }
-            }
-        }
-
-        let standard_name = format!("{}_fuzz", program_name);
-        let standard_path = PathBuf::from(target_dir).join(profile).join(&standard_name);
-        if exists_fn(&standard_path) {
-            return Ok(standard_path);
-        }
+/// Find the fuzz harness binary. The generated Cargo.toml always names the binary
+/// `invariant_test` via `[[bin]]`, so the path is predictable.
+/// Use different binary name if supplied.
+fn find_fuzz_binary(fuzz_dir: &Path, profile: &str) -> Result<PathBuf> {
+    let path = fuzz_dir.join("target").join(profile).join("invariant_test");
+    if path.exists() {
+        return Ok(path);
     }
-
-    let package_name = format!("{}_fuzz", program_name);
-    let fallback = fuzz_dir.join("target").join(profile).join(&package_name);
-    if exists_fn(&fallback) {
-        return Ok(fallback);
-    }
-
     bail!(
-        "Fuzz binary not found. Searched for package matching '{}' in target directory.\n\
-         Build it first with: crucible run {} <test_name> --release",
-        program_name,
-        program_name
-    )
-}
-
-fn find_fuzz_binary(fuzz_dir: &Path, program_name: &str, profile: &str) -> Result<PathBuf> {
-    // Try cargo metadata first (if cargo is available)
-    if has_cargo() {
-        if let Ok(output) = Command::new("cargo")
-            .current_dir(fuzz_dir)
-            .args(["metadata", "--format-version=1", "--no-deps"])
-            .output()
-        {
-            if output.status.success() {
-                if let Ok(metadata) = serde_json::from_slice::<serde_json::Value>(&output.stdout) {
-                    return resolve_binary_from_metadata(
-                        &metadata,
-                        fuzz_dir,
-                        program_name,
-                        profile,
-                        |p| p.exists(),
-                    );
-                }
-            }
-        }
-    }
-
-    // Fallback: scan target directory for binaries without cargo metadata
-    let target_dir = fuzz_dir.join("target").join(profile);
-    if target_dir.exists() {
-        // Try common naming patterns
-        let candidates = [
-            format!("{}_fuzz", program_name),
-            format!("{}-fuzz", program_name),
-            program_name.replace('-', "_"),
-            program_name.to_string(),
-        ];
-        for name in &candidates {
-            let path = target_dir.join(name);
-            if path.exists() {
-                return Ok(path);
-            }
-        }
-
-        // If there's exactly one executable in target/<profile>/, use it
-        if let Ok(entries) = fs::read_dir(&target_dir) {
-            let executables: Vec<_> = entries
-                .filter_map(|e| e.ok())
-                .filter(|e| {
-                    let path = e.path();
-                    path.is_file()
-                        && !path
-                            .extension()
-                            .map_or(false, |ext| ext == "d" || ext == "json" || ext == "rmeta")
-                        && !e.file_name().to_string_lossy().starts_with('.')
-                        && is_executable(&path)
-                })
-                .collect();
-            if executables.len() == 1 {
-                return Ok(executables[0].path());
-            }
-        }
-    }
-
-    bail!(
-        "Fuzz binary not found. Searched for package matching '{}' in target directory.\n\
-         Build it first with: crucible run {} <test_name> --release",
-        program_name,
-        program_name
+        "Fuzz binary not found at: {}\nBuild it first with: crucible run <program> <test_name> --release",
+        path.display()
     )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
-    use std::collections::HashSet;
-
-    /// Build fake cargo metadata JSON for testing.
-    fn make_metadata(target_dir: &str, packages: serde_json::Value) -> serde_json::Value {
-        json!({
-            "target_directory": target_dir,
-            "packages": packages
-        })
-    }
-
-    fn make_package(name: &str, bin_targets: &[&str]) -> serde_json::Value {
-        let targets: Vec<_> = bin_targets
-            .iter()
-            .map(|bin_name| {
-                json!({
-                    "name": bin_name,
-                    "kind": ["bin"]
-                })
-            })
-            .collect();
-        json!({
-            "name": name,
-            "targets": targets
-        })
-    }
-
-    /// Returns an exists_fn that says "yes" for any path in `existing`.
-    fn exists_set(existing: &[&str]) -> impl Fn(&Path) -> bool {
-        let set: HashSet<PathBuf> = existing.iter().map(PathBuf::from).collect();
-        move |p: &Path| set.contains(p)
-    }
-
-    // === Regression: package name doesn't contain program name (solana_program_fuzz vs "stake") ===
 
     #[test]
-    fn test_single_package_unrelated_name_found_via_fallback() {
-        // This is the exact scenario: package is "solana_program_fuzz", program is "stake"
-        let metadata = make_metadata(
-            "/project/fuzz/stake/target",
-            json!([make_package(
-                "solana_program_fuzz",
-                &["solana_program_fuzz"]
-            )]),
-        );
-        let existing = exists_set(&["/project/fuzz/stake/target/release/solana_program_fuzz"]);
+    fn test_find_fuzz_binary_finds_invariant_test() {
+        let temp = tempfile::tempdir().unwrap();
+        let target_dir = temp.path().join("target/release");
+        fs::create_dir_all(&target_dir).unwrap();
+        fs::write(target_dir.join("invariant_test"), b"").unwrap();
 
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project/fuzz/stake"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/fuzz/stake/target/release/solana_program_fuzz")
-        );
+        let result = find_fuzz_binary(temp.path(), "release");
+        assert!(result.is_ok(), "should find invariant_test: {:?}", result);
+        assert!(result.unwrap().ends_with("invariant_test"));
     }
 
     #[test]
-    fn test_single_package_with_explicit_bin_target_different_name() {
-        // Package "my_fuzz_harness" with [[bin]] name = "custom_bin", searching for "stake"
-        let metadata = make_metadata(
-            "/project/target",
-            json!([make_package("my_fuzz_harness", &["custom_bin"])]),
-        );
-        let existing = exists_set(&["/project/target/release/custom_bin"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/release/custom_bin")
-        );
-    }
-
-    // === Name matching still works when package name contains program name ===
-
-    #[test]
-    fn test_name_match_package_contains_program() {
-        // Package "stake_fuzz" contains "stake" — should match on first pass
-        let metadata = make_metadata(
-            "/project/target",
-            json!([make_package("stake_fuzz", &["stake_fuzz"])]),
-        );
-        let existing = exists_set(&["/project/target/release/stake_fuzz"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/release/stake_fuzz")
-        );
-    }
-
-    #[test]
-    fn test_name_match_with_hyphens_normalized() {
-        // Program "my-program", package "my_program_fuzz"
-        let metadata = make_metadata(
-            "/project/target",
-            json!([make_package("my_program_fuzz", &["my_program_fuzz"])]),
-        );
-        let existing = exists_set(&["/project/target/release/my_program_fuzz"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "my-program",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/release/my_program_fuzz")
-        );
-    }
-
-    // === Multiple packages: should NOT fallback to unrelated package ===
-
-    #[test]
-    fn test_multiple_packages_no_match_fails() {
-        // Two packages, neither contains "stake" — should fail (no single-package fallback)
-        let metadata = make_metadata(
-            "/project/target",
-            json!([make_package("foo", &["foo"]), make_package("bar", &["bar"])]),
-        );
-        let existing = exists_set(&["/project/target/release/foo", "/project/target/release/bar"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
+    fn test_find_fuzz_binary_fails_when_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = find_fuzz_binary(temp.path(), "release");
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_multiple_packages_picks_matching_one() {
-        // Two packages, one matches "stake"
-        let metadata = make_metadata(
-            "/project/target",
-            json!([
-                make_package("unrelated", &["unrelated"]),
-                make_package("stake_harness", &["stake_harness"])
-            ]),
-        );
-        let existing = exists_set(&[
-            "/project/target/release/unrelated",
-            "/project/target/release/stake_harness",
-        ]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/release/stake_harness")
-        );
-    }
-
-    // === Explicit [[bin]] target preferred over package name ===
-
-    #[test]
-    fn test_explicit_bin_target_preferred() {
-        // Package "stake_fuzz" has [[bin]] name = "my_binary"
-        let metadata = make_metadata(
-            "/project/target",
-            json!([{
-                "name": "stake_fuzz",
-                "targets": [
-                    { "name": "my_binary", "kind": ["bin"] },
-                    { "name": "stake_fuzz", "kind": ["lib"] }
-                ]
-            }]),
-        );
-        let existing = exists_set(&["/project/target/release/my_binary"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/release/my_binary")
-        );
-    }
-
-    // === standard_name fallback ({program}_fuzz) ===
-
-    #[test]
-    fn test_standard_name_fallback() {
-        // No packages match, but target_dir/release/stake_fuzz exists
-        let metadata = make_metadata("/project/target", json!([]));
-        let existing = exists_set(&["/project/target/release/stake_fuzz"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/release/stake_fuzz")
-        );
-    }
-
-    // === fuzz_dir fallback ===
-
-    #[test]
-    fn test_fuzz_dir_fallback() {
-        // Empty target_dir in metadata, but fuzz_dir/target/release/stake_fuzz exists
-        let metadata = make_metadata("", json!([]));
-        let existing = exists_set(&["/project/fuzz/stake/target/release/stake_fuzz"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project/fuzz/stake"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/fuzz/stake/target/release/stake_fuzz")
-        );
-    }
-
-    // === Nothing found ===
-
-    #[test]
-    fn test_nothing_found_returns_error() {
-        let metadata = make_metadata("/project/target", json!([]));
-        let existing = exists_set(&[]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "release",
-            existing,
-        );
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Fuzz binary not found"));
-    }
-
-    // === Debug profile ===
-
-    #[test]
-    fn test_debug_profile() {
-        let metadata = make_metadata(
-            "/project/target",
-            json!([make_package("stake", &["stake"])]),
-        );
-        let existing = exists_set(&["/project/target/debug/stake"]);
-
-        let result = resolve_binary_from_metadata(
-            &metadata,
-            Path::new("/project"),
-            "stake",
-            "debug",
-            existing,
-        );
-        assert_eq!(
-            result.unwrap(),
-            PathBuf::from("/project/target/debug/stake")
-        );
-    }
-
-    // === No-cargo binary fallback tests ===
-    // These test the fallback path in find_fuzz_binary that scans the target
-    // directory directly without cargo metadata (for environments without cargo).
-
-    #[cfg(unix)]
-    fn make_executable(path: &Path) {
-        use std::os::unix::fs::PermissionsExt;
-        fs::write(path, "#!/bin/sh\n").unwrap();
-        fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_fallback_finds_program_name_fuzz_binary() {
-        // Simulates: no cargo, binary at target/release/stake_fuzz
-        let temp = tempfile::tempdir().unwrap();
-        let target_dir = temp.path().join("target/release");
-        fs::create_dir_all(&target_dir).unwrap();
-        make_executable(&target_dir.join("stake_fuzz"));
-
-        // resolve_binary_from_metadata would fail without cargo metadata,
-        // so test the fallback scan directly by calling find_fuzz_binary
-        // with a fuzz_dir that has no Cargo.toml (cargo metadata will fail)
-        let result = find_fuzz_binary(temp.path(), "stake", "release");
-        assert!(
-            result.is_ok(),
-            "should find stake_fuzz binary: {:?}",
-            result
-        );
-        assert!(result.unwrap().ends_with("stake_fuzz"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_fallback_finds_hyphenated_binary() {
-        let temp = tempfile::tempdir().unwrap();
-        let target_dir = temp.path().join("target/release");
-        fs::create_dir_all(&target_dir).unwrap();
-        make_executable(&target_dir.join("stake-fuzz"));
-
-        let result = find_fuzz_binary(temp.path(), "stake", "release");
-        assert!(
-            result.is_ok(),
-            "should find stake-fuzz binary: {:?}",
-            result
-        );
-        assert!(result.unwrap().ends_with("stake-fuzz"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_fallback_finds_exact_name_binary() {
-        let temp = tempfile::tempdir().unwrap();
-        let target_dir = temp.path().join("target/release");
-        fs::create_dir_all(&target_dir).unwrap();
-        make_executable(&target_dir.join("stake"));
-
-        let result = find_fuzz_binary(temp.path(), "stake", "release");
-        assert!(result.is_ok(), "should find stake binary: {:?}", result);
-        assert!(result.unwrap().ends_with("stake"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_fallback_finds_sole_executable() {
-        // When there's only one executable in target/release/, use it
-        // regardless of name (matches the single-package cargo metadata logic)
-        let temp = tempfile::tempdir().unwrap();
-        let target_dir = temp.path().join("target/release");
-        fs::create_dir_all(&target_dir).unwrap();
-        make_executable(&target_dir.join("solana_program_fuzz"));
-        // Also create non-executable files that should be ignored
-        fs::write(target_dir.join("solana_program_fuzz.d"), "dep info").unwrap();
-        fs::write(target_dir.join(".fingerprint"), "").unwrap();
-
-        let result = find_fuzz_binary(temp.path(), "stake", "release");
-        assert!(result.is_ok(), "should find sole executable: {:?}", result);
-        assert!(result.unwrap().ends_with("solana_program_fuzz"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_fallback_fails_when_no_binary() {
-        let temp = tempfile::tempdir().unwrap();
-        let target_dir = temp.path().join("target/release");
-        fs::create_dir_all(&target_dir).unwrap();
-        // Empty target dir, no binaries
-
-        let result = find_fuzz_binary(temp.path(), "stake", "release");
-        assert!(result.is_err(), "should fail when no binary found");
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn test_fallback_fails_when_no_target_dir() {
-        let temp = tempfile::tempdir().unwrap();
-        // No target/ directory at all
-
-        let result = find_fuzz_binary(temp.path(), "stake", "release");
-        assert!(result.is_err(), "should fail when target dir missing");
     }
 
     #[test]
     fn test_try_cargo_build_returns_true_when_cargo_available() {
-        // has_cargo() should return true in test environment
         assert!(has_cargo(), "cargo should be available in test env");
     }
 
@@ -2714,17 +2048,17 @@ mod tests {
         // run_replay passes crash_path as FUZZ_INPUT_FILE env var.
         // If crash_path is relative to cwd but binary runs from fuzz_dir,
         // it must be canonicalized to an absolute path.
-        // We can't easily test the full Command execution, but we can verify
-        // the canonicalize logic doesn't panic on non-existent paths.
+        // Non-existent path returns Err (caller gets "Crash file not found").
         let crash = Path::new("crashes/invariant_test/crash_abc123");
-        let abs = crash.canonicalize().unwrap_or_else(|_| crash.to_path_buf());
-        // Non-existent path falls back to the original (no panic)
-        assert_eq!(abs, crash.to_path_buf());
+        assert!(
+            crash.canonicalize().is_err(),
+            "non-existent crash path should fail canonicalize"
+        );
 
-        // Existing path gets canonicalized
+        // Existing path canonicalizes to an absolute path.
         let tmp = std::env::temp_dir().join("crucible_test_crash_replay");
         std::fs::write(&tmp, b"test").unwrap();
-        let abs = tmp.canonicalize().unwrap_or_else(|_| tmp.clone());
+        let abs = tmp.canonicalize().unwrap();
         assert!(abs.is_absolute());
         std::fs::remove_file(&tmp).unwrap();
     }

--- a/crates/crucible-fuzz-cli/src/templates.rs
+++ b/crates/crucible-fuzz-cli/src/templates.rs
@@ -1,0 +1,145 @@
+pub fn generate_cargo_toml(program_name: &str) -> String {
+    let repo = "https://github.com/asymmetric-research/crucible";
+    let branch = "main";
+
+    format!(
+        r#"[package]
+name = "{program_name}_fuzz"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+# Standalone workspace - isolated from parent project to avoid Solana version conflicts
+
+[dependencies]
+# Fuzzing framework
+crucible-fuzzer = {{ git = "{repo}", branch = "{branch}" }}
+crucible-test-context = {{ git = "{repo}", branch = "{branch}" }}
+crucible-idl-gen = {{ git = "{repo}", branch = "{branch}" }}
+
+# Anchor (v3-compatible fork with solana-sysvar ~3.1 fix)
+anchor-lang = {{ git = "https://github.com/asymmetric-research/anchor-fuzzing", branch = "feature/fuzzing" }}
+
+# Solana v3.x (required for litesvm 0.9.0)
+solana-pubkey = "3.0"
+solana-keypair = "3.1"
+solana-signer = "3.0"
+solana-program = "3.0"
+solana-message = "3.0"
+solana-signature = "3.1"
+solana-instruction = "3.1"
+
+# Fuzzing
+libafl = {{ version = "0.15.1", features = ["std", "cli", "prelude"] }}
+libafl_bolts = {{ version = "0.15.1", features = ["std"] }}
+arbitrary = {{ version = "1", features = ["derive"] }}
+
+# Utilities
+anyhow = "1.0"
+bytemuck = "1.14"
+ctor = "0.6"
+
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
+
+[features]
+invariant_test = []
+"#
+    )
+}
+
+pub fn generate_harness(program_name: &str) -> String {
+    let fixture_name = to_pascal_case(program_name);
+    format!(
+        r#"use crucible_fuzzer::*;
+use anchor_lang::prelude::*;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use solana_pubkey::Pubkey;
+use anchor_lang::system_program;
+use std::rc::Rc;
+
+// Generate types from IDL (no crate dependency - avoids version conflicts)
+crucible_idl_gen::declare_fuzz_program!("idls/{program_name}.json");
+
+use {program_name}::instruction;
+use {program_name}::accounts;
+
+#[derive(Clone)]
+struct {fixture_name} {{
+    ctx: TestContext,
+    program_id: Pubkey,
+    admin: Rc<Keypair>,
+    // TODO: Add your state here (users, accounts, etc.)
+}}
+
+#[fuzz_fixture]
+impl {fixture_name} {{
+    /// Called ONCE to setup initial state (programs + accounts)
+    pub fn setup() -> Self {{
+        let mut ctx = TestContext::new();
+        let program_id = {program_name}::ID;
+
+        // Load program binary (built separately from fuzz harness)
+        ctx.add_program(&program_id, "../../target/deploy/{program_name}.so").unwrap();
+
+        // Create admin account
+        let admin = Rc::new(Keypair::new());
+        ctx.create_account()
+            .pubkey(admin.pubkey())
+            .lamports(100_000_000_000)
+            .owner(system_program::ID)
+            .create()
+            .unwrap();
+
+        // TODO: Initialize your program state here
+
+        Self {{ ctx, program_id, admin }}
+    }}
+
+    /// ACTIONS - Define actions that the fuzzer can call
+    pub fn action_noop(&mut self) {{
+        // Placeholder - replace with real actions
+    }}
+
+    // TODO: Add your actions here
+}}
+
+#[invariant_test]
+fn invariant_test(fixture: &mut {fixture_name}) {{
+    // TODO: Add invariant checks that should hold after every action
+}}
+"#,
+    )
+}
+
+pub fn generate_idl_readme(program_name: &str) -> String {
+    format!(
+        r#"# IDL Files
+
+Place your program's IDL JSON file here as `{program_name}.json`.
+
+## Generating IDL
+
+If you have the legacy (v0.29) IDL format:
+```bash
+anchor idl convert target/idl/{program_name}.json -o fuzz/{program_name}/idls/{program_name}.json
+```
+
+If you have the new IDL format (v0.30+), copy it directly.
+"#
+    )
+}
+
+pub fn to_pascal_case(s: &str) -> String {
+    s.split(|c: char| c == '_' || c == '-')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+            }
+        })
+        .collect()
+}

--- a/crates/crucible-fuzzer/tests/cli.rs
+++ b/crates/crucible-fuzzer/tests/cli.rs
@@ -73,14 +73,29 @@ fn test_init_creates_workspace() {
     // Check created structure
     let fuzz_dir = temp.path().join("fuzz/my_program");
     assert!(fuzz_dir.exists(), "fuzz/my_program should exist");
-    assert!(fuzz_dir.join("Cargo.toml").exists(), "Cargo.toml should exist");
-    assert!(fuzz_dir.join("rust-toolchain.toml").exists(), "rust-toolchain.toml should exist");
-    assert!(fuzz_dir.join("src/main.rs").exists(), "src/main.rs should exist");
-    assert!(fuzz_dir.join("idls").is_dir(), "idls/ should be a directory");
+    assert!(
+        fuzz_dir.join("Cargo.toml").exists(),
+        "Cargo.toml should exist"
+    );
+    assert!(
+        fuzz_dir.join("rust-toolchain.toml").exists(),
+        "rust-toolchain.toml should exist"
+    );
+    assert!(
+        fuzz_dir.join("src/main.rs").exists(),
+        "src/main.rs should exist"
+    );
+    assert!(
+        fuzz_dir.join("idls").is_dir(),
+        "idls/ should be a directory"
+    );
 
     // Verify Cargo.toml contains [workspace]
     let cargo_content = fs::read_to_string(fuzz_dir.join("Cargo.toml")).unwrap();
-    assert!(cargo_content.contains("[workspace]"), "Cargo.toml should declare [workspace]");
+    assert!(
+        cargo_content.contains("[workspace]"),
+        "Cargo.toml should declare [workspace]"
+    );
 }
 
 #[test]
@@ -95,7 +110,10 @@ fn test_init_idempotent() {
 
     // Second init should fail (directory already exists)
     let output2 = run_crucible_in(temp.path(), &["init", "my_program"]);
-    assert!(!output2.status.success(), "second init should fail - directory exists");
+    assert!(
+        !output2.status.success(),
+        "second init should fail - directory exists"
+    );
 
     let stderr = String::from_utf8_lossy(&output2.stderr);
     assert!(
@@ -119,15 +137,21 @@ fn test_run_dry_run() {
         return;
     }
 
-    let output = run_crucible_in(&marginfi_path, &["run", "marginfi-v2-fuzz", "invariant_test", "--dry-run"]);
+    let output = run_crucible_in(
+        &marginfi_path,
+        &["run", "marginfi-v2-fuzz", "invariant_test", "--dry-run"],
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Dry-run should print validation message
     assert!(
-        stdout.contains("Dry-run") || stderr.contains("Dry-run") || stdout.contains("dry-run") || stderr.contains("dry-run"),
-        "output should mention dry-run mode"
+        stdout.contains("Dry-run")
+            || stderr.contains("Dry-run")
+            || stdout.contains("dry-run")
+            || stderr.contains("dry-run"),
+        "output should mention dry-run mode, stdout: {stdout}, stderr: {stderr}",
     );
 }
 
@@ -138,7 +162,10 @@ fn test_run_nonexistent_harness() {
     let temp = TempDir::new().unwrap();
     let output = run_crucible_in(temp.path(), &["run", "nonexistent", "test", "--dry-run"]);
 
-    assert!(!output.status.success(), "run should fail for nonexistent harness");
+    assert!(
+        !output.status.success(),
+        "run should fail for nonexistent harness"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -165,13 +192,27 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
-    let output = run_crucible_in(temp.path(), &["run", "test_prog", "test_feature", "--timeout", "30", "--dry-run"]);
+    let output = run_crucible_in(
+        temp.path(),
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--timeout",
+            "30",
+            "--dry-run",
+        ],
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -198,23 +239,36 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--corpus-out", "./my_corpus", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--corpus-out",
+            "./my_corpus",
+            "--dry-run",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
+    let _ = temp.keep();
     // CLI should print message about corpus output
     assert!(
         stdout.contains("my_corpus") || stdout.contains("corpus"),
-        "CLI should acknowledge corpus-out in output"
+        "CLI should acknowledge corpus-out in output {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 
@@ -234,22 +288,36 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--cores", "4", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--cores",
+            "4",
+            "--dry-run",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     // CLI should print message about multi-core
     assert!(
-        stdout.contains("4") && (stdout.contains("core") || stdout.contains("worker") || stdout.contains("parallel")),
+        stdout.contains("4")
+            && (stdout.contains("core")
+                || stdout.contains("worker")
+                || stdout.contains("parallel")),
         "CLI should acknowledge multi-core setting in output"
     );
 }
@@ -270,15 +338,26 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--seed", "12345", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--seed",
+            "12345",
+            "--dry-run",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -306,15 +385,26 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--max-actions", "20", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--max-actions",
+            "20",
+            "--dry-run",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -322,7 +412,8 @@ test_feature = []
     // CLI should print message about max actions
     assert!(
         stdout.contains("20") && stdout.contains("ax actions"),
-        "CLI should acknowledge max-actions setting in output, got: {}", stdout
+        "CLI should acknowledge max-actions setting in output, got: {}",
+        stdout
     );
 }
 
@@ -340,7 +431,9 @@ fn test_list_no_fuzz_dir() {
     // Should succeed but indicate no fuzz directory
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("No fuzz") || stdout.contains("not found") || stdout.to_lowercase().contains("no fuzz"),
+        stdout.contains("No fuzz")
+            || stdout.contains("not found")
+            || stdout.to_lowercase().contains("no fuzz"),
         "should indicate no fuzz directory found"
     );
 }
@@ -363,13 +456,17 @@ name = "{}_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test1 = []
 test2 = []
 "#,
                 name
             ),
-        ).unwrap();
+        )
+        .unwrap();
         fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
     }
 
@@ -397,12 +494,16 @@ name = "my_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 default = []
 invariant_test = []
 property_test = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(temp.path(), &["list", "my_prog"]);
@@ -410,10 +511,19 @@ property_test = []
 
     assert!(output.status.success(), "list should succeed");
     assert!(stdout.contains("my_prog"), "should show program name");
-    assert!(stdout.contains("invariant_test"), "should list invariant_test feature");
-    assert!(stdout.contains("property_test"), "should list property_test feature");
+    assert!(
+        stdout.contains("invariant_test"),
+        "should list invariant_test feature"
+    );
+    assert!(
+        stdout.contains("property_test"),
+        "should list property_test feature"
+    );
     // default is filtered out
-    assert!(!stdout.contains("- default"), "should not list default feature as a test");
+    assert!(
+        !stdout.contains("- default"),
+        "should not list default feature as a test"
+    );
 }
 
 #[test]
@@ -423,7 +533,10 @@ fn test_list_nonexistent_program() {
     let temp = TempDir::new().unwrap();
     let output = run_crucible_in(temp.path(), &["list", "nonexistent"]);
 
-    assert!(!output.status.success(), "list should fail for nonexistent program");
+    assert!(
+        !output.status.success(),
+        "list should fail for nonexistent program"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -453,7 +566,8 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(temp.path(), &["show", "my_prog"]);
@@ -486,7 +600,8 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Write a crash metadata file
@@ -500,14 +615,18 @@ edition = "2021"
                 {"name": "action_deposit", "params": {"amount": 100}, "success": true}
             ]
         }"#,
-    ).unwrap();
+    )
+    .unwrap();
 
     let output = run_crucible_in(temp.path(), &["show", "my_prog"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     assert!(output.status.success(), "show should succeed");
     assert!(stdout.contains("crash_abc123"), "should list the crash");
-    assert!(stdout.contains("1 total") || stdout.contains("1)"), "should show crash count");
+    assert!(
+        stdout.contains("1 total") || stdout.contains("1)"),
+        "should show crash count"
+    );
 }
 
 #[test]
@@ -530,7 +649,8 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Write crash metadata
@@ -546,7 +666,8 @@ edition = "2021"
                 {"name": "action_withdraw", "params": {"user": 0, "amount": 1000}, "success": false}
             ]
         }"#,
-    ).unwrap();
+    )
+    .unwrap();
 
     let output = run_crucible_in(temp.path(), &["show", "my_prog", "crash_xyz"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -556,14 +677,29 @@ edition = "2021"
     assert!(stdout.contains("invariant_test"), "should show test name");
     assert!(stdout.contains("999"), "should show iteration");
     assert!(stdout.contains("54321"), "should show seed");
-    assert!(stdout.contains("action_deposit"), "should show first action");
-    assert!(stdout.contains("action_withdraw"), "should show second action");
+    assert!(
+        stdout.contains("action_deposit"),
+        "should show first action"
+    );
+    assert!(
+        stdout.contains("action_withdraw"),
+        "should show second action"
+    );
     assert!(stdout.contains("2 actions"), "should show action count");
 
     // Parameter value assertions
-    assert!(stdout.contains("user=0"), "should show user param value for deposit");
-    assert!(stdout.contains("amount=500"), "should show amount param value for deposit");
-    assert!(stdout.contains("amount=1000"), "should show amount param value for withdraw");
+    assert!(
+        stdout.contains("user=0"),
+        "should show user param value for deposit"
+    );
+    assert!(
+        stdout.contains("amount=500"),
+        "should show amount param value for deposit"
+    );
+    assert!(
+        stdout.contains("amount=1000"),
+        "should show amount param value for withdraw"
+    );
     assert!(stdout.contains("OK"), "should show success status");
     assert!(stdout.contains("FAIL"), "should show failure status");
 }
@@ -588,12 +724,16 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(temp.path(), &["show", "my_prog", "nonexistent_crash"]);
 
-    assert!(!output.status.success(), "show should fail for nonexistent crash");
+    assert!(
+        !output.status.success(),
+        "show should fail for nonexistent crash"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -621,7 +761,8 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Crash metadata with diverse parameter types including no-param action
@@ -637,7 +778,8 @@ edition = "2021"
                 {"name": "action_withdraw", "params": {"user": 2, "amount": 42}, "success": false}
             ]
         }"#,
-    ).unwrap();
+    )
+    .unwrap();
 
     let output = run_crucible_in(temp.path(), &["show", "my_prog", "crash_params"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -646,9 +788,15 @@ edition = "2021"
 
     // Numbers render correctly
     assert!(stdout.contains("user=1"), "should show user=1 for deposit");
-    assert!(stdout.contains("amount=999"), "should show amount=999 for deposit");
+    assert!(
+        stdout.contains("amount=999"),
+        "should show amount=999 for deposit"
+    );
     assert!(stdout.contains("user=2"), "should show user=2 for withdraw");
-    assert!(stdout.contains("amount=42"), "should show amount=42 for withdraw");
+    assert!(
+        stdout.contains("amount=42"),
+        "should show amount=42 for withdraw"
+    );
 
     // No-param action should not have parens
     // Expected format: "2. action_noop -> OK" (not "action_noop() -> OK")
@@ -666,7 +814,10 @@ edition = "2021"
     // Status indicators
     assert!(stdout.contains("OK"), "should show OK for success");
     assert!(stdout.contains("FAIL"), "should show FAIL for failure");
-    assert!(stdout.contains("3 actions"), "should show 3 actions in header");
+    assert!(
+        stdout.contains("3 actions"),
+        "should show 3 actions in header"
+    );
 }
 
 #[test]
@@ -688,7 +839,8 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     fs::write(
@@ -728,7 +880,10 @@ edition = "2021"
     );
 
     // Header should show action count
-    assert!(stdout.contains("3 actions"), "header should show '3 actions'");
+    assert!(
+        stdout.contains("3 actions"),
+        "header should show '3 actions'"
+    );
 }
 
 #[test]
@@ -750,7 +905,8 @@ version = "0.1.0"
 edition = "2021"
 [workspace]
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     fs::write(
@@ -763,7 +919,8 @@ edition = "2021"
                 {"name": "action_deposit", "params": {"amount": 100}, "success": true}
             ]
         }"#,
-    ).unwrap();
+    )
+    .unwrap();
 
     let output = run_crucible_in(temp.path(), &["show", "my_prog", "crash_hint"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -797,16 +954,23 @@ name = "my_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Write crash binary file (just some bytes)
     fs::write(crashes_dir.join("crash_replay"), b"some crash bytes").unwrap();
 
-    let output = run_crucible_in(temp.path(), &["show", "my_prog", "crash_replay", "--replay"]);
+    let output = run_crucible_in(
+        temp.path(),
+        &["show", "my_prog", "crash_replay", "--replay"],
+    );
 
     // Replay may fail because the binary doesn't produce meaningful output,
     // or succeed with "completed without crash". Either way it should not panic.
@@ -817,7 +981,9 @@ test = []
     // The build should be attempted with --features test (the test directory name)
     assert!(
         combined.contains("Building with --features test") || combined.contains("Build failed"),
-        "replay should attempt to build with correct feature. got:\nstdout: {}\nstderr: {}", stdout, stderr
+        "replay should attempt to build with correct feature. got:\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
     );
 }
 
@@ -844,17 +1010,24 @@ name = "my_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 invariant_test_a = []
 invariant_test_b = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Put crash in test_b directory
     fs::write(crashes_dir_b.join("crash_abc123"), b"crash bytes").unwrap();
 
-    let output = run_crucible_in(temp.path(), &["show", "my_prog", "crash_abc123", "--replay"]);
+    let output = run_crucible_in(
+        temp.path(),
+        &["show", "my_prog", "crash_abc123", "--replay"],
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -863,7 +1036,9 @@ invariant_test_b = []
     // Should build with --features invariant_test_b (NOT invariant_test_a)
     assert!(
         combined.contains("Building with --features invariant_test_b"),
-        "should build with feature from crash directory. got:\nstdout: {}\nstderr: {}", stdout, stderr
+        "should build with feature from crash directory. got:\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
     );
 }
 
@@ -887,10 +1062,14 @@ name = "my_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(
@@ -898,7 +1077,10 @@ test = []
         &["cmin", "my_prog", "test", "./nonexistent_corpus"],
     );
 
-    assert!(!output.status.success(), "cmin should fail for nonexistent corpus");
+    assert!(
+        !output.status.success(),
+        "cmin should fail for nonexistent corpus"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -923,26 +1105,31 @@ name = "my_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Create empty corpus directory
     let corpus_dir = temp.path().join("corpus");
     fs::create_dir_all(&corpus_dir).unwrap();
 
-    let output = run_crucible_in(
-        temp.path(),
-        &["cmin", "my_prog", "test", "./corpus"],
-    );
+    let output = run_crucible_in(temp.path(), &["cmin", "my_prog", "test", "./corpus"]);
 
-    assert!(!output.status.success(), "cmin should fail for empty corpus");
+    assert!(
+        !output.status.success(),
+        "cmin should fail for empty corpus"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("No corpus inputs") || stderr.to_lowercase().contains("no") && stderr.to_lowercase().contains("inputs"),
+        stderr.contains("No corpus inputs")
+            || stderr.to_lowercase().contains("no") && stderr.to_lowercase().contains("inputs"),
         "error should mention no inputs found"
     );
 }
@@ -958,12 +1145,12 @@ fn test_cmin_nonexistent_harness() {
     fs::create_dir_all(&corpus_dir).unwrap();
     fs::write(corpus_dir.join("input1"), b"test input").unwrap();
 
-    let output = run_crucible_in(
-        temp.path(),
-        &["cmin", "nonexistent", "test", "./corpus"],
-    );
+    let output = run_crucible_in(temp.path(), &["cmin", "nonexistent", "test", "./corpus"]);
 
-    assert!(!output.status.success(), "cmin should fail for nonexistent harness");
+    assert!(
+        !output.status.success(),
+        "cmin should fail for nonexistent harness"
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
@@ -1004,23 +1191,36 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Use nonexistent corpus-in - CLI should skip it with a message
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--corpus-in", "./no_such_corpus", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--corpus-in",
+            "./no_such_corpus",
+            "--dry-run",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     // CLI should print a skip message (not fail)
     assert!(
-        stdout.contains("does not exist") || stdout.contains("skipping") || stdout.to_lowercase().contains("skip"),
+        stdout.contains("does not exist")
+            || stdout.contains("skipping")
+            || stdout.to_lowercase().contains("skip"),
         "CLI should mention skipping nonexistent corpus-in"
     );
 }
@@ -1041,15 +1241,25 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--stop-on-crash", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--stop-on-crash",
+            "--dry-run",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1076,10 +1286,14 @@ name = "test_prog_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 test_feature = []
 "#,
-    ).unwrap();
+    )
+    .unwrap();
     fs::write(fuzz_dir.join("src/main.rs"), "fn main() {}").unwrap();
 
     // Create corpus directory for coverage-only mode
@@ -1091,7 +1305,14 @@ test_feature = []
     // (coverage + corpus-in + no timeout + no input)
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--coverage", "--corpus-in", "./corpus"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--coverage",
+            "--corpus-in",
+            "./corpus",
+        ],
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1102,7 +1323,9 @@ test_feature = []
     let combined = format!("{}\n{}", stdout, stderr);
     assert!(
         combined.to_lowercase().contains("coverage"),
-        "CLI should mention coverage mode. stdout: {}, stderr: {}", stdout, stderr
+        "CLI should mention coverage mode. stdout: {}, stderr: {}",
+        stdout,
+        stderr
     );
 }
 
@@ -1115,10 +1338,7 @@ test_feature = []
 fn create_stub_fuzz_dir(base: &Path, prog: &str, features: &[&str]) -> std::path::PathBuf {
     let fuzz_dir = base.join("fuzz").join(prog);
     fs::create_dir_all(fuzz_dir.join("src")).unwrap();
-    let feats: String = features
-        .iter()
-        .map(|f| format!("{} = []\n", f))
-        .collect();
+    let feats: String = features.iter().map(|f| format!("{} = []\n", f)).collect();
     fs::write(
         fuzz_dir.join("Cargo.toml"),
         format!(
@@ -1127,6 +1347,9 @@ name = "{prog}_fuzz"
 version = "0.1.0"
 edition = "2021"
 [workspace]
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
 [features]
 {feats}"#
         ),
@@ -1148,12 +1371,19 @@ fn test_run_no_tracing_message() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--no-tracing", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--no-tracing",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Tracing disabled"),
-        "expected 'Tracing disabled' in stdout, got: {}", stdout
+        "expected 'Tracing disabled' in stdout, got: {}",
+        stdout
     );
 }
 
@@ -1165,12 +1395,19 @@ fn test_run_stateful_message() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--stateful", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--stateful",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Stateful mode"),
-        "expected 'Stateful mode' in stdout, got: {}", stdout
+        "expected 'Stateful mode' in stdout, got: {}",
+        stdout
     );
 }
 
@@ -1182,12 +1419,21 @@ fn test_run_max_depth_message() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--stateful", "--max-depth", "25", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--stateful",
+            "--max-depth",
+            "25",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Max state depth: 25"),
-        "expected 'Max state depth: 25' in stdout, got: {}", stdout
+        "expected 'Max state depth: 25' in stdout, got: {}",
+        stdout
     );
 }
 
@@ -1203,12 +1449,20 @@ fn test_run_symbols_message() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--symbols", "./symbols.so", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--symbols",
+            "./symbols.so",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Debug symbols:"),
-        "expected 'Debug symbols:' in stdout, got: {}", stdout
+        "expected 'Debug symbols:' in stdout, got: {}",
+        stdout
     );
 }
 
@@ -1220,12 +1474,20 @@ fn test_run_lcov_out_message() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--lcov-out", "./cov.lcov", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--lcov-out",
+            "./cov.lcov",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("LCOV output:"),
-        "expected 'LCOV output:' in stdout, got: {}", stdout
+        "expected 'LCOV output:' in stdout, got: {}",
+        stdout
     );
 }
 
@@ -1247,7 +1509,8 @@ fn test_run_replay_message() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Replaying input:"),
-        "expected 'Replaying input:' in stdout, got: {}", stdout
+        "expected 'Replaying input:' in stdout, got: {}",
+        stdout
     );
 }
 
@@ -1263,11 +1526,27 @@ fn test_run_stateful_with_max_depth() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--stateful", "--max-depth", "30", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--stateful",
+            "--max-depth",
+            "30",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Stateful mode"), "missing stateful message, got: {}", stdout);
-    assert!(stdout.contains("Max state depth: 30"), "missing max depth message, got: {}", stdout);
+    assert!(
+        stdout.contains("Stateful mode"),
+        "missing stateful message, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Max state depth: 30"),
+        "missing max depth message, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -1278,11 +1557,28 @@ fn test_run_cores_with_timeout() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--cores", "8", "--timeout", "60", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--cores",
+            "8",
+            "--timeout",
+            "60",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("8 parallel workers"), "missing cores message, got: {}", stdout);
-    assert!(stdout.contains("60s timeout"), "missing timeout message, got: {}", stdout);
+    assert!(
+        stdout.contains("8 parallel workers"),
+        "missing cores message, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("60s timeout"),
+        "missing timeout message, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -1299,12 +1595,20 @@ fn test_run_coverage_corpus_in_triggers_coverage_only() {
     // coverage + corpus-in + no timeout + no dry-run + no replay → coverage-only mode
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--coverage", "--corpus-in", "./corpus"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--coverage",
+            "--corpus-in",
+            "./corpus",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Coverage-only mode"),
-        "expected 'Coverage-only mode', got: {}", stdout
+        "expected 'Coverage-only mode', got: {}",
+        stdout
     );
 }
 
@@ -1321,12 +1625,22 @@ fn test_run_coverage_corpus_in_with_timeout_skips_coverage_only() {
     // coverage + corpus-in + timeout → NOT coverage-only (timeout means fuzzing, not just coverage)
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--coverage", "--corpus-in", "./corpus", "--timeout", "30"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--coverage",
+            "--corpus-in",
+            "./corpus",
+            "--timeout",
+            "30",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Coverage-only mode"),
-        "should NOT trigger coverage-only mode with --timeout, got: {}", stdout
+        "should NOT trigger coverage-only mode with --timeout, got: {}",
+        stdout
     );
 }
 
@@ -1342,31 +1656,86 @@ fn test_run_all_flags_together() {
     let output = run_crucible_in(
         temp.path(),
         &[
-            "run", "test_prog", "test_feature",
-            "--stateful", "--max-depth", "20",
+            "run",
+            "test_prog",
+            "test_feature",
+            "--stateful",
+            "--max-depth",
+            "20",
             "--no-tracing",
-            "--cores", "2", "--timeout", "10",
-            "--seed", "42",
+            "--cores",
+            "2",
+            "--timeout",
+            "10",
+            "--seed",
+            "42",
             "--stop-on-crash",
-            "--max-actions", "5",
-            "--symbols", "./symbols.so",
-            "--lcov-out", "./out.lcov",
+            "--max-actions",
+            "5",
+            "--symbols",
+            "./symbols.so",
+            "--lcov-out",
+            "./out.lcov",
             "--dry-run",
         ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    assert!(stdout.contains("Stateful mode"), "missing stateful, got: {}", stdout);
-    assert!(stdout.contains("Max state depth: 20"), "missing depth, got: {}", stdout);
-    assert!(stdout.contains("Tracing disabled"), "missing no-tracing, got: {}", stdout);
-    assert!(stdout.contains("2 parallel workers"), "missing cores, got: {}", stdout);
-    assert!(stdout.contains("10s timeout"), "missing timeout, got: {}", stdout);
-    assert!(stdout.contains("Using seed: 42"), "missing seed, got: {}", stdout);
-    assert!(stdout.contains("Stop-on-crash"), "missing stop-on-crash, got: {}", stdout);
-    assert!(stdout.contains("Max actions per iteration: 5"), "missing max-actions, got: {}", stdout);
-    assert!(stdout.contains("Debug symbols:"), "missing symbols, got: {}", stdout);
-    assert!(stdout.contains("LCOV output:"), "missing lcov-out, got: {}", stdout);
-    assert!(stdout.contains("Dry-run mode"), "missing dry-run, got: {}", stdout);
+    assert!(
+        stdout.contains("Stateful mode"),
+        "missing stateful, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Max state depth: 20"),
+        "missing depth, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Tracing disabled"),
+        "missing no-tracing, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("2 parallel workers"),
+        "missing cores, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("10s timeout"),
+        "missing timeout, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Using seed: 42"),
+        "missing seed, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Stop-on-crash"),
+        "missing stop-on-crash, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Max actions per iteration: 5"),
+        "missing max-actions, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Debug symbols:"),
+        "missing symbols, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("LCOV output:"),
+        "missing lcov-out, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Dry-run mode"),
+        "missing dry-run, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -1382,7 +1751,8 @@ fn test_run_j_shorthand_for_cores() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("4 parallel workers"),
-        "expected '-j 4' to produce '4 parallel workers', got: {}", stdout
+        "expected '-j 4' to produce '4 parallel workers', got: {}",
+        stdout
     );
 }
 
@@ -1403,7 +1773,8 @@ fn test_run_mode_dry_run() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Dry-run mode"),
-        "expected 'Dry-run mode', got: {}", stdout
+        "expected 'Dry-run mode', got: {}",
+        stdout
     );
 }
 
@@ -1416,13 +1787,36 @@ fn test_run_mode_explore_defaults() {
     // No ./corpus directory → explore mode should NOT load corpus
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "explore", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "explore",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Stop-on-crash"), "explore should enable stop-on-crash, got: {}", stdout);
-    assert!(stdout.contains("Writing corpus to:") && stdout.contains("output"), "explore should set corpus-out to output, got: {}", stdout);
-    assert!(stdout.contains("Crashes directory:") && stdout.contains("output"), "explore should set crashes-out to output, got: {}", stdout);
-    assert!(!stdout.contains("Loading corpus from:"), "should not load corpus when ./corpus doesn't exist, got: {}", stdout);
+    assert!(
+        stdout.contains("Stop-on-crash"),
+        "explore should enable stop-on-crash, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Writing corpus to:") && stdout.contains("output"),
+        "explore should set corpus-out to output, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Crashes directory:") && stdout.contains("output"),
+        "explore should set crashes-out to output, got: {}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("Loading corpus from:"),
+        "should not load corpus when ./corpus doesn't exist, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -1438,12 +1832,20 @@ fn test_run_mode_explore_with_corpus() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "explore", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "explore",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Loading corpus from:"),
-        "explore should auto-load ./corpus when it exists, got: {}", stdout
+        "explore should auto-load ./corpus when it exists, got: {}",
+        stdout
     );
 }
 
@@ -1459,12 +1861,22 @@ fn test_run_mode_explore_explicit_overrides() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "explore", "--corpus-in", "./seeds", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "explore",
+            "--corpus-in",
+            "./seeds",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Loading corpus from:") && stdout.contains("seeds"),
-        "explicit --corpus-in should override explore default, got: {}", stdout
+        "explicit --corpus-in should override explore default, got: {}",
+        stdout
     );
 }
 
@@ -1486,11 +1898,13 @@ fn test_run_mode_coverage_defaults() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Coverage-only mode"),
-        "coverage mode should trigger coverage-only, got: {}", stdout
+        "coverage mode should trigger coverage-only, got: {}",
+        stdout
     );
     assert!(
         stdout.contains("LCOV output:"),
-        "coverage mode should set lcov output, got: {}", stdout
+        "coverage mode should set lcov output, got: {}",
+        stdout
     );
 }
 
@@ -1506,12 +1920,21 @@ fn test_run_mode_coverage_with_lcov_out() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "coverage", "--lcov-out", "./my.lcov"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "coverage",
+            "--lcov-out",
+            "./my.lcov",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("LCOV output:") && stdout.contains("my.lcov"),
-        "explicit --lcov-out should be used in coverage mode, got: {}", stdout
+        "explicit --lcov-out should be used in coverage mode, got: {}",
+        stdout
     );
 }
 
@@ -1533,7 +1956,8 @@ fn test_run_mode_reproduce_with_input() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Replaying input:") && stdout.contains("test_input"),
-        "reproduce mode should find and replay input file, got: {}", stdout
+        "reproduce mode should find and replay input file, got: {}",
+        stdout
     );
 }
 
@@ -1546,12 +1970,20 @@ fn test_run_mode_reproduce_no_input() {
     // No ./input directory → reproduce mode should not set replay
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "reproduce", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "reproduce",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Replaying input:"),
-        "reproduce mode with no input dir should not replay, got: {}", stdout
+        "reproduce mode with no input dir should not replay, got: {}",
+        stdout
     );
 }
 
@@ -1569,7 +2001,8 @@ fn test_run_mode_invalid() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Unknown mode: foobar"),
-        "should report unknown mode, got: {}", stderr
+        "should report unknown mode, got: {}",
+        stderr
     );
 }
 
@@ -1581,12 +2014,22 @@ fn test_run_mode_with_flag_override() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "explore", "--crashes-out", "./custom", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "explore",
+            "--crashes-out",
+            "./custom",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Crashes directory:") && stdout.contains("custom"),
-        "explicit --crashes-out should override explore default, got: {}", stdout
+        "explicit --crashes-out should override explore default, got: {}",
+        stdout
     );
 }
 
@@ -1606,12 +2049,20 @@ fn test_run_corpus_in_empty_dir_skipped() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--corpus-in", "./corpus", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--corpus-in",
+            "./corpus",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("empty, skipping"),
-        "empty corpus dir should be skipped, got: {}", stdout
+        "empty corpus dir should be skipped, got: {}",
+        stdout
     );
 }
 
@@ -1627,12 +2078,20 @@ fn test_run_corpus_in_with_files_loaded() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--corpus-in", "./corpus", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--corpus-in",
+            "./corpus",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Loading corpus from:"),
-        "corpus dir with files should be loaded, got: {}", stdout
+        "corpus dir with files should be loaded, got: {}",
+        stdout
     );
 }
 
@@ -1648,8 +2107,12 @@ fn test_run_crashes_out_default() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Crashes directory:") && stdout.contains("crashes") && stdout.contains("test_feature"),
-        "default crashes dir should contain 'crashes' and test name, got: {}", stdout
+        stdout.contains("Crashes directory:")
+            && stdout.contains("crashes")
+            && stdout.contains("test_prog")
+            && stdout.contains("test_feature"),
+        "default crashes dir should contain 'crashes' and test name, got: {}",
+        stdout
     );
 }
 
@@ -1665,8 +2128,9 @@ fn test_run_max_actions_default() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Max actions per iteration: 10"),
-        "default max-actions should be 10, got: {}", stdout
+        stdout.contains("Max actions per iteration: 8"),
+        "default max-actions should be 8, got: {}",
+        stdout
     );
 }
 
@@ -1752,7 +2216,8 @@ fn test_run_no_subcommand() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Usage") || stderr.contains("usage") || stderr.contains("USAGE"),
-        "should show usage info, got: {}", stderr
+        "should show usage info, got: {}",
+        stderr
     );
 }
 
@@ -1766,29 +2231,8 @@ fn test_run_missing_test_name() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("required") || stderr.contains("error") || stderr.contains("Usage"),
-        "should show error about missing argument, got: {}", stderr
-    );
-}
-
-#[test]
-fn test_run_unknown_feature_passes_cli() {
-    ensure_cli_built();
-    let temp = TempDir::new().unwrap();
-    create_stub_fuzz_dir(temp.path(), "test_prog", &["real_feature"]);
-
-    // CLI should proceed even with a feature that isn't in Cargo.toml
-    // (feature validation is cargo's responsibility, not CLI's)
-    let output = run_crucible_in(
-        temp.path(),
-        &["run", "test_prog", "unknown_feature", "--dry-run"],
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // CLI should at least print its messages before handing off to cargo
-    assert!(
-        stdout.contains("Dry-run mode") || stdout.contains("Max actions"),
-        "CLI should proceed with unknown feature, got stdout: {}, stderr: {}",
-        stdout,
-        String::from_utf8_lossy(&output.stderr)
+        "should show error about missing argument, got: {}",
+        stderr
     );
 }
 
@@ -1801,15 +2245,16 @@ fn test_tmin_nonexistent_harness() {
     ensure_cli_built();
     let temp = TempDir::new().unwrap();
 
-    let output = run_crucible_in(
-        temp.path(),
-        &["tmin", "nonexistent", "test"],
+    let output = run_crucible_in(temp.path(), &["tmin", "nonexistent", "test"]);
+    assert!(
+        !output.status.success(),
+        "tmin should fail for nonexistent harness"
     );
-    assert!(!output.status.success(), "tmin should fail for nonexistent harness");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("does not exist") || stderr.contains("not found"),
-        "should report missing harness, got: {}", stderr
+        "should report missing harness, got: {}",
+        stderr
     );
 }
 
@@ -1827,7 +2272,13 @@ fn test_cmin_corpus_in_flag() {
     // Use --corpus-in flag instead of positional arg
     let output = run_crucible_in(
         temp.path(),
-        &["cmin", "test_prog", "test_feature", "--corpus-in", "./corpus"],
+        &[
+            "cmin",
+            "test_prog",
+            "test_feature",
+            "--corpus-in",
+            "./corpus",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     // Should accept the flag and start minimization (will fail at cargo build, which is fine)
@@ -1851,11 +2302,26 @@ fn test_run_stateful_no_tracing_combination() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--stateful", "--no-tracing", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--stateful",
+            "--no-tracing",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Stateful mode"), "missing stateful, got: {}", stdout);
-    assert!(stdout.contains("Tracing disabled"), "missing no-tracing, got: {}", stdout);
+    assert!(
+        stdout.contains("Stateful mode"),
+        "missing stateful, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("Tracing disabled"),
+        "missing no-tracing, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -1867,12 +2333,20 @@ fn test_run_corpus_out_creates_message() {
     // --corpus-out to a dir that doesn't exist yet — CLI should still print the message
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--corpus-out", "./new_dir", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--corpus-out",
+            "./new_dir",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Writing corpus to:") && stdout.contains("new_dir"),
-        "expected corpus-out message, got: {}", stdout
+        "expected corpus-out message, got: {}",
+        stdout
     );
 }
 
@@ -1884,12 +2358,20 @@ fn test_run_crashes_out_custom_path() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--crashes-out", "./my_crashes", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--crashes-out",
+            "./my_crashes",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Crashes directory:") && stdout.contains("my_crashes"),
-        "expected custom crashes path, got: {}", stdout
+        "expected custom crashes path, got: {}",
+        stdout
     );
 }
 
@@ -1901,12 +2383,20 @@ fn test_run_max_actions_custom() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--max-actions", "1", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--max-actions",
+            "1",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Max actions per iteration: 1"),
-        "expected max-actions 1, got: {}", stdout
+        "expected max-actions 1, got: {}",
+        stdout
     );
 }
 
@@ -1918,12 +2408,20 @@ fn test_run_max_actions_large() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--max-actions", "1000", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--max-actions",
+            "1000",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Max actions per iteration: 1000"),
-        "expected max-actions 1000, got: {}", stdout
+        "expected max-actions 1000, got: {}",
+        stdout
     );
 }
 
@@ -1935,12 +2433,20 @@ fn test_run_seed_zero() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--seed", "0", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--seed",
+            "0",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Using seed: 0"),
-        "seed 0 should be valid, got: {}", stdout
+        "seed 0 should be valid, got: {}",
+        stdout
     );
 }
 
@@ -1952,12 +2458,20 @@ fn test_run_seed_large() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--seed", "18446744073709551615", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--seed",
+            "18446744073709551615",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Using seed: 18446744073709551615"),
-        "u64 max seed should be valid, got: {}", stdout
+        "u64 max seed should be valid, got: {}",
+        stdout
     );
 }
 
@@ -1969,12 +2483,20 @@ fn test_run_cores_one() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--cores", "1", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--cores",
+            "1",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("1 parallel workers"),
-        "cores=1 should still print multi-core message, got: {}", stdout
+        "cores=1 should still print multi-core message, got: {}",
+        stdout
     );
 }
 
@@ -1991,11 +2513,15 @@ fn test_run_multiple_harnesses_requires_exact_name() {
         temp.path(),
         &["run", "wrong_name", "test_feature", "--dry-run"],
     );
-    assert!(!output.status.success(), "should fail with multiple harnesses and wrong name");
+    assert!(
+        !output.status.success(),
+        "should fail with multiple harnesses and wrong name"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("does not exist"),
-        "should report not found, got: {}", stderr
+        "should report not found, got: {}",
+        stderr
     );
 }
 
@@ -2007,12 +2533,22 @@ fn test_run_mode_explore_corpus_out_override() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--mode", "explore", "--corpus-out", "./custom", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--mode",
+            "explore",
+            "--corpus-out",
+            "./custom",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Writing corpus to:") && stdout.contains("custom"),
-        "explicit --corpus-out should override explore default, got: {}", stdout
+        "explicit --corpus-out should override explore default, got: {}",
+        stdout
     );
 }
 
@@ -2029,12 +2565,21 @@ fn test_run_dry_run_does_not_trigger_coverage_only() {
     // coverage + corpus-in + dry-run → should NOT trigger coverage-only mode
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--coverage", "--corpus-in", "./corpus", "--dry-run"],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--coverage",
+            "--corpus-in",
+            "./corpus",
+            "--dry-run",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Coverage-only mode"),
-        "dry-run should suppress coverage-only mode, got: {}", stdout
+        "dry-run should suppress coverage-only mode, got: {}",
+        stdout
     );
 }
 
@@ -2054,12 +2599,22 @@ fn test_run_replay_does_not_trigger_coverage_only() {
     // coverage + corpus-in + replay → should NOT trigger coverage-only mode
     let output = run_crucible_in(
         temp.path(),
-        &["run", "test_prog", "test_feature", "--coverage", "--corpus-in", "./corpus", "--replay", input_file.to_str().unwrap()],
+        &[
+            "run",
+            "test_prog",
+            "test_feature",
+            "--coverage",
+            "--corpus-in",
+            "./corpus",
+            "--replay",
+            input_file.to_str().unwrap(),
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         !stdout.contains("Coverage-only mode"),
-        "replay should suppress coverage-only mode, got: {}", stdout
+        "replay should suppress coverage-only mode, got: {}",
+        stdout
     );
 }
 
@@ -2075,10 +2630,7 @@ fn test_tmin_no_crash_file_no_all() {
 
     // tmin with test name but no crash file and no --all
     // Should try to resolve crash dirs and fail (no crashes dir exists)
-    let output = run_crucible_in(
-        temp.path(),
-        &["tmin", "test_prog", "test_feature"],
-    );
+    let output = run_crucible_in(temp.path(), &["tmin", "test_prog", "test_feature"]);
     // This should either fail or proceed to build (which fails on stub)
     // Either way it shouldn't panic
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -2097,17 +2649,18 @@ fn test_tmin_all_flag_with_harness() {
     create_stub_fuzz_dir(temp.path(), "test_prog", &["test_feature"]);
 
     // --all flag with valid harness → should proceed to build step
-    let output = run_crucible_in(
-        temp.path(),
-        &["tmin", "test_prog", "test_feature", "--all"],
-    );
+    let output = run_crucible_in(temp.path(), &["tmin", "test_prog", "test_feature", "--all"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{}\n{}", stdout, stderr);
     // Should attempt to build (which will fail on our stub, but that's fine)
     assert!(
-        combined.contains("Building") || combined.contains("Compiling") || combined.contains("error") || combined.contains("No crashes"),
-        "tmin --all should proceed past CLI parsing, got: {}", combined
+        combined.contains("Building")
+            || combined.contains("Compiling")
+            || combined.contains("error")
+            || combined.contains("No crashes"),
+        "tmin --all should proceed past CLI parsing, got: {}",
+        combined
     );
 }
 
@@ -2123,17 +2676,17 @@ fn test_tmin_crash_id_auto_detect() {
     fs::write(crashes_dir.join("crash_xyz"), b"crash data").unwrap();
 
     // Use 2-arg form: tmin prog crash_xyz → should auto-detect test from crash dirs
-    let output = run_crucible_in(
-        temp.path(),
-        &["tmin", "test_prog", "crash_xyz"],
-    );
+    let output = run_crucible_in(temp.path(), &["tmin", "test_prog", "crash_xyz"]);
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{}\n{}", stdout, stderr);
     // Should find the crash and proceed to building with invariant_test feature
     assert!(
-        combined.contains("invariant_test") || combined.contains("Building") || combined.contains("Compiling"),
-        "should auto-detect test name from crash dir, got: {}", combined
+        combined.contains("invariant_test")
+            || combined.contains("Building")
+            || combined.contains("Compiling"),
+        "should auto-detect test name from crash dir, got: {}",
+        combined
     );
 }
 
@@ -2147,15 +2700,13 @@ fn test_tmin_crash_id_not_found() {
     fs::create_dir_all(fuzz_dir.join("crashes/test_feature")).unwrap();
 
     // 2-arg form with nonexistent crash
-    let output = run_crucible_in(
-        temp.path(),
-        &["tmin", "test_prog", "crash_nothere"],
-    );
+    let output = run_crucible_in(temp.path(), &["tmin", "test_prog", "crash_nothere"]);
     assert!(!output.status.success(), "should fail when crash not found");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Could not find crash") || stderr.contains("not found"),
-        "should report crash not found, got: {}", stderr
+        "should report crash not found, got: {}",
+        stderr
     );
 }
 
@@ -2175,13 +2726,21 @@ fn test_cmin_with_corpus_out() {
 
     let output = run_crucible_in(
         temp.path(),
-        &["cmin", "test_prog", "test_feature", "./corpus", "--corpus-out", "./corpus_min"],
+        &[
+            "cmin",
+            "test_prog",
+            "test_feature",
+            "./corpus",
+            "--corpus-out",
+            "./corpus_min",
+        ],
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("Output directory:") || stdout.contains("Minimizing"),
         "should show output dir or minimizing message, got stdout: {}, stderr: {}",
-        stdout, String::from_utf8_lossy(&output.stderr)
+        stdout,
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 
@@ -2192,15 +2751,13 @@ fn test_cmin_no_corpus_arg() {
     create_stub_fuzz_dir(temp.path(), "test_prog", &["test_feature"]);
 
     // No positional corpus arg and no --corpus-in
-    let output = run_crucible_in(
-        temp.path(),
-        &["cmin", "test_prog", "test_feature"],
-    );
+    let output = run_crucible_in(temp.path(), &["cmin", "test_prog", "test_feature"]);
     assert!(!output.status.success(), "should fail without corpus arg");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Corpus directory required") || stderr.contains("required"),
-        "should report missing corpus, got: {}", stderr
+        "should report missing corpus, got: {}",
+        stderr
     );
 }
 
@@ -2220,15 +2777,29 @@ fn test_cmin_positional_and_flag_both_work() {
         &["cmin", "test_prog", "test_feature", "./corpus"],
     );
     let stdout1 = String::from_utf8_lossy(&output1.stdout);
-    assert!(stdout1.contains("[CMIN]"), "positional should work, got: {}", stdout1);
+    assert!(
+        stdout1.contains("[CMIN]"),
+        "positional should work, got: {}",
+        stdout1
+    );
 
     // Flag
     let output2 = run_crucible_in(
         temp.path(),
-        &["cmin", "test_prog", "test_feature", "--corpus-in", "./corpus"],
+        &[
+            "cmin",
+            "test_prog",
+            "test_feature",
+            "--corpus-in",
+            "./corpus",
+        ],
     );
     let stdout2 = String::from_utf8_lossy(&output2.stdout);
-    assert!(stdout2.contains("[CMIN]"), "flag should work, got: {}", stdout2);
+    assert!(
+        stdout2.contains("[CMIN]"),
+        "flag should work, got: {}",
+        stdout2
+    );
 }
 
 // =============================================================================
@@ -2245,8 +2816,14 @@ fn test_init_creates_gitignore() {
     let gitignore = temp.path().join("fuzz/.gitignore");
     assert!(gitignore.exists(), "fuzz/.gitignore should exist");
     let content = fs::read_to_string(&gitignore).unwrap();
-    assert!(content.contains("target"), ".gitignore should ignore target dirs");
-    assert!(content.contains("crashes"), ".gitignore should ignore crashes dirs");
+    assert!(
+        content.contains("target"),
+        ".gitignore should ignore target dirs"
+    );
+    assert!(
+        content.contains("crashes"),
+        ".gitignore should ignore crashes dirs"
+    );
 }
 
 #[test]
@@ -2258,8 +2835,14 @@ fn test_init_cargo_toml_has_features() {
 
     let cargo_toml = temp.path().join("fuzz/my_program/Cargo.toml");
     let content = fs::read_to_string(&cargo_toml).unwrap();
-    assert!(content.contains("[features]"), "should have [features] section");
-    assert!(content.contains("invariant_test"), "should have invariant_test feature");
+    assert!(
+        content.contains("[features]"),
+        "should have [features] section"
+    );
+    assert!(
+        content.contains("invariant_test"),
+        "should have invariant_test feature"
+    );
 }
 
 // =============================================================================
@@ -2299,7 +2882,9 @@ fn ensure_test_program_built() -> bool {
 #[test]
 #[ignore]
 fn test_e2e_corpus_in_nonexistent() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let nonexistent = temp.path().join("does_not_exist");
@@ -2314,13 +2899,19 @@ fn test_e2e_corpus_in_nonexistent() {
     let combined = format!("{}\n{}", stdout, stderr);
 
     // Dry-run should succeed even without corpus
-    assert!(success || combined.contains("Dry-run"), "Dry-run should work without corpus. Output: {}", combined);
+    assert!(
+        success || combined.contains("Dry-run"),
+        "Dry-run should work without corpus. Output: {}",
+        combined
+    );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_corpus_in_empty() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let empty_dir = temp.path().join("empty_corpus");
@@ -2338,14 +2929,17 @@ fn test_e2e_corpus_in_empty() {
     // The key is it shouldn't crash
     assert!(
         combined.contains("Dry-run") || combined.contains("seed") || combined.contains("corpus"),
-        "Should handle empty corpus. Output: {}", combined
+        "Should handle empty corpus. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_corpus_out_creates_dir() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("new_corpus_dir");
@@ -2361,14 +2955,17 @@ fn test_e2e_corpus_out_creates_dir() {
     // The corpus output directory should be created
     assert!(
         corpus_out.exists(),
-        "Corpus output directory should be created. Output: {}", combined
+        "Corpus output directory should be created. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_corpus_in_out_count_match() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2392,20 +2989,24 @@ fn test_e2e_corpus_in_out_count_match() {
     // So we just verify the fuzzer ran and produced some output
     assert!(
         combined.contains("corpus") || combined.contains("exec"),
-        "Fuzzer should run with corpus. Output: {}", combined
+        "Fuzzer should run with corpus. Output: {}",
+        combined
     );
 
     // Output corpus should exist (may be empty if no coverage from inputs)
     assert!(
         corpus_out.exists(),
-        "Corpus output directory should be created. Output: {}", combined
+        "Corpus output directory should be created. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_corpus_roundtrip_singlecore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2427,14 +3028,18 @@ fn test_e2e_corpus_roundtrip_singlecore() {
     let out_count = common::count_corpus_files(&corpus_out);
     assert!(
         out_count >= 1,
-        "Single-core corpus output should have files. Got {}. Output: {}", out_count, combined
+        "Single-core corpus output should have files. Got {}. Output: {}",
+        out_count,
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_corpus_roundtrip_multicore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2461,7 +3066,9 @@ fn test_e2e_corpus_roundtrip_multicore() {
         let out_count = common::count_corpus_files(&corpus_out);
         assert!(
             out_count >= 1,
-            "Multi-core corpus output should have files. Got {}. Output: {}", out_count, combined
+            "Multi-core corpus output should have files. Got {}. Output: {}",
+            out_count,
+            combined
         );
     } else {
         eprintln!("[MULTICORE] Hard timeout reached - multicore exit may need investigation");
@@ -2471,7 +3078,9 @@ fn test_e2e_corpus_roundtrip_multicore() {
 #[test]
 #[ignore]
 fn test_e2e_corpus_same_dir_singlecore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -2494,14 +3103,18 @@ fn test_e2e_corpus_same_dir_singlecore() {
     assert!(
         final_count >= initial_count,
         "Same-dir corpus should preserve files. Initial: {}, Final: {}. Output: {}",
-        initial_count, final_count, combined
+        initial_count,
+        final_count,
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_corpus_same_dir_multicore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -2529,7 +3142,9 @@ fn test_e2e_corpus_same_dir_multicore() {
         assert!(
             final_count >= initial_count,
             "Multi-core same-dir corpus should preserve files. Initial: {}, Final: {}. Output: {}",
-            initial_count, final_count, combined
+            initial_count,
+            final_count,
+            combined
         );
     } else {
         eprintln!("[MULTICORE] Hard timeout reached - multicore exit may need investigation");
@@ -2543,7 +3158,9 @@ fn test_e2e_corpus_same_dir_multicore() {
 #[test]
 #[ignore]
 fn test_e2e_cmin_reduces_corpus() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2562,7 +3179,10 @@ fn test_e2e_cmin_reduces_corpus() {
     let pre_cmin_count = common::count_corpus_files(&corpus_in);
     if pre_cmin_count < 5 {
         // Not enough inputs to meaningfully test reduction
-        eprintln!("Skipping cmin test: not enough corpus entries generated ({})", pre_cmin_count);
+        eprintln!(
+            "Skipping cmin test: not enough corpus entries generated ({})",
+            pre_cmin_count
+        );
         return;
     }
 
@@ -2575,21 +3195,29 @@ fn test_e2e_cmin_reduces_corpus() {
 
     let combined = format!("{}\n{}", stdout, stderr);
 
-    assert!(success || combined.contains("[CMIN]"), "Cmin should run. Output: {}", combined);
+    assert!(
+        success || combined.contains("[CMIN]"),
+        "Cmin should run. Output: {}",
+        combined
+    );
 
     // Output should have fewer or equal inputs
     let post_cmin_count = common::count_corpus_files(&corpus_out);
     assert!(
         post_cmin_count <= pre_cmin_count,
         "Cmin should reduce corpus. Before: {}, After: {}. Output: {}",
-        pre_cmin_count, post_cmin_count, combined
+        pre_cmin_count,
+        post_cmin_count,
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_cmin_inplace() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -2618,14 +3246,18 @@ fn test_e2e_cmin_inplace() {
     assert!(
         post_count < pre_count,
         "In-place cmin should remove redundant inputs. Before: {}, After: {}. Output: {}",
-        pre_count, post_count, combined
+        pre_count,
+        post_count,
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_cmin_to_new_dir() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2646,13 +3278,15 @@ fn test_e2e_cmin_to_new_dir() {
     // Cmin should run (success means it completed)
     assert!(
         success || combined.contains("[CMIN]"),
-        "Cmin should run. Output: {}", combined
+        "Cmin should run. Output: {}",
+        combined
     );
 
     // Output dir should be created
     assert!(
         corpus_out.exists(),
-        "Cmin should create output directory. Output: {}", combined
+        "Cmin should create output directory. Output: {}",
+        combined
     );
 
     // Note: If harness doesn't generate coverage, cmin may select 0 inputs
@@ -2667,7 +3301,9 @@ fn test_e2e_cmin_to_new_dir() {
 #[test]
 #[ignore]
 fn test_e2e_cmin_creates_output_dir() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2686,14 +3322,17 @@ fn test_e2e_cmin_creates_output_dir() {
 
     assert!(
         corpus_out.exists(),
-        "Cmin should create nested output directory. Output: {}", combined
+        "Cmin should create nested output directory. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_cmin_skips_metadata() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -2721,7 +3360,8 @@ fn test_e2e_cmin_skips_metadata() {
     // Should report 2 input files, not 5
     assert!(
         combined.contains("2 input") || combined.contains("Found 2"),
-        "Cmin should only count actual inputs, not metadata. Output: {}", combined
+        "Cmin should only count actual inputs, not metadata. Output: {}",
+        combined
     );
 }
 
@@ -2732,7 +3372,9 @@ fn test_e2e_cmin_skips_metadata() {
 #[test]
 #[ignore]
 fn test_e2e_seed_deterministic() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out_1 = temp.path().join("corpus_1");
@@ -2768,7 +3410,9 @@ fn test_e2e_seed_deterministic() {
 #[test]
 #[ignore]
 fn test_e2e_different_seeds_diverge() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out_1 = temp.path().join("corpus_1");
@@ -2802,7 +3446,9 @@ fn test_e2e_different_seeds_diverge() {
 #[test]
 #[ignore]
 fn test_e2e_input_replay() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -2832,30 +3478,32 @@ fn test_e2e_input_replay() {
     let input_path = inputs[0].path();
 
     // Replay the input
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", input_path.to_str().unwrap()),
-    ]);
+    let (stdout, stderr, _) =
+        common::run_test_program_fuzz(&[("FUZZ_INPUT_FILE", input_path.to_str().unwrap())]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
     // Should mention replay or run the input
     assert!(
-        combined.contains("Replay") || combined.contains("replay") ||
-        combined.contains("input") || combined.contains("iteration"),
-        "Replay should execute the input. Output: {}", combined
+        combined.contains("Replay")
+            || combined.contains("replay")
+            || combined.contains("input")
+            || combined.contains("iteration"),
+        "Replay should execute the input. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_timeout_respected() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let start = std::time::Instant::now();
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_TIMEOUT_SECS", "3"),
-    ]);
+    let (stdout, stderr, _) = common::run_test_program_fuzz(&[("FUZZ_TIMEOUT_SECS", "3")]);
 
     let elapsed = start.elapsed();
     let combined = format!("{}\n{}", stdout, stderr);
@@ -2863,20 +3511,25 @@ fn test_e2e_timeout_respected() {
     // Should exit within reasonable time (3s timeout + some buffer)
     assert!(
         elapsed.as_secs() < 10,
-        "Fuzzer should respect timeout. Took {}s. Output: {}", elapsed.as_secs(), combined
+        "Fuzzer should respect timeout. Took {}s. Output: {}",
+        elapsed.as_secs(),
+        combined
     );
 
     // Should mention timeout
     assert!(
         combined.to_lowercase().contains("timeout") || elapsed.as_secs() <= 5,
-        "Should mention timeout or exit quickly. Output: {}", combined
+        "Should mention timeout or exit quickly. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_coverage_writes_lcov() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -2898,13 +3551,14 @@ fn test_e2e_coverage_writes_lcov() {
     let combined = format!("{}\n{}", stdout, stderr);
 
     // Check if coverage was written - either file exists OR output says it was written
-    let lcov_written = lcov_path.exists() ||
-        combined.contains("[LCOV] Coverage written") ||
-        combined.contains("coverage.lcov");
+    let lcov_written = lcov_path.exists()
+        || combined.contains("[LCOV] Coverage written")
+        || combined.contains("coverage.lcov");
 
     assert!(
         lcov_written,
-        "coverage.lcov should be created. Output: {}", combined
+        "coverage.lcov should be created. Output: {}",
+        combined
     );
 
     // Clean up
@@ -2918,28 +3572,34 @@ fn test_e2e_coverage_writes_lcov() {
 #[test]
 #[ignore]
 fn test_e2e_invalid_input_file() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let nonexistent = temp.path().join("no_such_file");
 
-    let (stdout, stderr, success) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", nonexistent.to_str().unwrap()),
-    ]);
+    let (stdout, stderr, success) =
+        common::run_test_program_fuzz(&[("FUZZ_INPUT_FILE", nonexistent.to_str().unwrap())]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
     // Should fail or report error
     assert!(
-        !success || combined.to_lowercase().contains("error") || combined.to_lowercase().contains("not found"),
-        "Should report error for nonexistent input. Output: {}", combined
+        !success
+            || combined.to_lowercase().contains("error")
+            || combined.to_lowercase().contains("not found"),
+        "Should report error for nonexistent input. Output: {}",
+        combined
     );
 }
 
 #[test]
 #[ignore]
 fn test_e2e_cmin_requires_corpus_in() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("output");
@@ -2955,8 +3615,11 @@ fn test_e2e_cmin_requires_corpus_in() {
 
     // Should fail with error about missing corpus-in
     assert!(
-        !success || combined.contains("FUZZ_CORPUS_IN") || combined.to_lowercase().contains("required"),
-        "Cmin should require FUZZ_CORPUS_IN. Output: {}", combined
+        !success
+            || combined.contains("FUZZ_CORPUS_IN")
+            || combined.to_lowercase().contains("required"),
+        "Cmin should require FUZZ_CORPUS_IN. Output: {}",
+        combined
     );
 }
 
@@ -2972,7 +3635,9 @@ fn test_e2e_cmin_requires_corpus_in() {
 #[test]
 #[ignore]
 fn test_e2e_performance_stability_30s() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -2992,12 +3657,18 @@ fn test_e2e_performance_stability_30s() {
     let edges = common::parse_edges_count(&combined).unwrap_or(0);
     let crash_found = common::crash_detected(&combined);
 
-    eprintln!("[PERF-30s] Elapsed: {}s, Edges: {}, Crash found: {}", elapsed.as_secs(), edges, crash_found);
+    eprintln!(
+        "[PERF-30s] Elapsed: {}s, Edges: {}, Crash found: {}",
+        elapsed.as_secs(),
+        edges,
+        crash_found
+    );
 
     // Verify coverage was discovered
     assert!(
         edges > 0,
-        "Should discover some edges. Got 0. Output: {}", combined
+        "Should discover some edges. Got 0. Output: {}",
+        combined
     );
 
     // If fuzzer ran for full duration without crash, verify timing
@@ -3006,7 +3677,8 @@ fn test_e2e_performance_stability_30s() {
         assert!(
             elapsed.as_secs() >= 25 && elapsed.as_secs() <= 45,
             "Fuzzer should run for ~30 seconds when no crash. Took {}s. Output: {}",
-            elapsed.as_secs(), combined
+            elapsed.as_secs(),
+            combined
         );
     }
 }
@@ -3016,7 +3688,9 @@ fn test_e2e_performance_stability_30s() {
 #[test]
 #[ignore]
 fn test_e2e_performance_stability_60s() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3035,13 +3709,20 @@ fn test_e2e_performance_stability_60s() {
     let edges = common::parse_edges_count(&combined).unwrap_or(0);
     let crash_found = common::crash_detected(&combined);
 
-    eprintln!("[PERF-60s] Elapsed: {}s, Edges: {}, Crash found: {}", elapsed.as_secs(), edges, crash_found);
+    eprintln!(
+        "[PERF-60s] Elapsed: {}s, Edges: {}, Crash found: {}",
+        elapsed.as_secs(),
+        edges,
+        crash_found
+    );
 
     // Verify significant coverage was discovered
     // The staking program has ~4600 total edges, should discover at least 100
     assert!(
         edges > 100,
-        "Should discover >100 edges. Got {}. Output: {}", edges, combined
+        "Should discover >100 edges. Got {}. Output: {}",
+        edges,
+        combined
     );
 
     // If it found a crash, that's a successful outcome
@@ -3055,7 +3736,9 @@ fn test_e2e_performance_stability_60s() {
 #[test]
 #[ignore]
 fn test_e2e_multicore_performance_stability() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3077,25 +3760,35 @@ fn test_e2e_multicore_performance_stability() {
 
     // Handle multicore infrastructure failures gracefully
     // These can happen when running multiple multicore tests in sequence
-    if stderr == "TIMEOUT" || stderr.contains("Launcher failed") || stderr.contains("shmem socket") {
+    if stderr == "TIMEOUT" || stderr.contains("Launcher failed") || stderr.contains("shmem socket")
+    {
         eprintln!("[MULTICORE-PERF] Hard timeout or Launcher failure - multicore infra issue");
         return;
     }
 
     // Verify multi-core mode started
     assert!(
-        combined.contains("worker") || combined.contains("core") || combined.contains("parallel") || combined.contains("Launcher"),
-        "Multi-core mode should be indicated in output. Output: {}", combined
+        combined.contains("worker")
+            || combined.contains("core")
+            || combined.contains("parallel")
+            || combined.contains("Launcher"),
+        "Multi-core mode should be indicated in output. Output: {}",
+        combined
     );
 
     let edges = common::parse_edges_count(&combined).unwrap_or(0);
 
-    eprintln!("[MULTICORE-PERF] Elapsed: {}s, Edges: {}", elapsed.as_secs(), edges);
+    eprintln!(
+        "[MULTICORE-PERF] Elapsed: {}s, Edges: {}",
+        elapsed.as_secs(),
+        edges
+    );
 
     // Verify fuzzer ran and discovered coverage
     assert!(
         edges > 0,
-        "Multi-core should discover edges. Got 0. Output: {}", combined
+        "Multi-core should discover edges. Got 0. Output: {}",
+        combined
     );
 }
 
@@ -3107,7 +3800,9 @@ fn test_e2e_multicore_performance_stability() {
 #[test]
 #[ignore]
 fn test_e2e_invariant_violation_detected() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3127,7 +3822,10 @@ fn test_e2e_invariant_violation_detected() {
     let crash_found = common::crash_detected(&combined);
     let crash_files = common::count_crash_files(&crashes_dir);
 
-    eprintln!("[INVARIANT] Crash in output: {}, Crash files: {}", crash_found, crash_files);
+    eprintln!(
+        "[INVARIANT] Crash in output: {}, Crash files: {}",
+        crash_found, crash_files
+    );
     eprintln!("[INVARIANT] Output: {}", combined);
 
     // At least one indicator of crash detection
@@ -3140,7 +3838,8 @@ fn test_e2e_invariant_violation_detected() {
     // Verify fuzzer at least ran properly
     assert!(
         combined.contains("exec") || combined.contains("iteration"),
-        "Fuzzer should have run. Output: {}", combined
+        "Fuzzer should have run. Output: {}",
+        combined
     );
 }
 
@@ -3148,7 +3847,9 @@ fn test_e2e_invariant_violation_detected() {
 #[test]
 #[ignore]
 fn test_e2e_crash_files_written() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3174,18 +3875,24 @@ fn test_e2e_crash_files_written() {
             let meta_content = fs::read_to_string(meta_path).unwrap();
             assert!(
                 meta_content.contains("{") && meta_content.contains("}"),
-                "Crash metadata should be JSON: {}", meta_path.display()
+                "Crash metadata should be JSON: {}",
+                meta_path.display()
             );
 
             // Verify input file exists and is non-empty
             let input_size = fs::metadata(input_path).map(|m| m.len()).unwrap_or(0);
             assert!(
                 input_size > 0,
-                "Crash input file should be non-empty: {}", input_path.display()
+                "Crash input file should be non-empty: {}",
+                input_path.display()
             );
 
-            eprintln!("[CRASH] Metadata: {}, Input: {} ({} bytes)",
-                meta_path.display(), input_path.display(), input_size);
+            eprintln!(
+                "[CRASH] Metadata: {}, Input: {} ({} bytes)",
+                meta_path.display(),
+                input_path.display(),
+                input_size
+            );
         }
     } else {
         eprintln!("[CRASH] No crashes found in 30s. Output: {}", combined);
@@ -3196,7 +3903,9 @@ fn test_e2e_crash_files_written() {
 #[test]
 #[ignore]
 fn test_e2e_crash_replay() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3220,19 +3929,19 @@ fn test_e2e_crash_replay() {
     // Try to replay the first crash
     let (_, input_path) = &crashes[0];
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", input_path.to_str().unwrap()),
-    ]);
+    let (stdout, stderr, _) =
+        common::run_test_program_fuzz(&[("FUZZ_INPUT_FILE", input_path.to_str().unwrap())]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
     // Replay should indicate the crash was reproduced or show the sequence
     assert!(
-        combined.to_lowercase().contains("replay") ||
-        combined.to_lowercase().contains("sequence") ||
-        combined.to_lowercase().contains("action") ||
-        combined.to_lowercase().contains("violation"),
-        "Replay should show action sequence or indicate replay mode. Output: {}", combined
+        combined.to_lowercase().contains("replay")
+            || combined.to_lowercase().contains("sequence")
+            || combined.to_lowercase().contains("action")
+            || combined.to_lowercase().contains("violation"),
+        "Replay should show action sequence or indicate replay mode. Output: {}",
+        combined
     );
 
     eprintln!("[REPLAY] Replay output: {}", combined);
@@ -3242,7 +3951,9 @@ fn test_e2e_crash_replay() {
 #[test]
 #[ignore]
 fn test_e2e_replay_shows_violation_action() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3264,9 +3975,8 @@ fn test_e2e_replay_shows_violation_action() {
 
     let (_, input_path) = &crashes[0];
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", input_path.to_str().unwrap()),
-    ]);
+    let (stdout, stderr, _) =
+        common::run_test_program_fuzz(&[("FUZZ_INPUT_FILE", input_path.to_str().unwrap())]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
@@ -3275,13 +3985,17 @@ fn test_e2e_replay_shows_violation_action() {
     let has_sequence = combined.contains("SEQUENCE") || combined.contains("action_");
     let has_marker = combined.contains("[VIOLATION]") || combined.contains("FAIL");
 
-    eprintln!("[VIOLATION-ACTION] Has sequence: {}, Has marker: {}", has_sequence, has_marker);
+    eprintln!(
+        "[VIOLATION-ACTION] Has sequence: {}, Has marker: {}",
+        has_sequence, has_marker
+    );
     eprintln!("[VIOLATION-ACTION] Output: {}", combined);
 
     if has_sequence {
         assert!(
             has_marker || combined.contains("executed") || combined.contains("skipped"),
-            "Replay sequence should indicate which action failed. Output: {}", combined
+            "Replay sequence should indicate which action failed. Output: {}",
+            combined
         );
     }
 }
@@ -3294,7 +4008,9 @@ fn test_e2e_replay_shows_violation_action() {
 #[test]
 #[ignore]
 fn test_e2e_edge_discovery() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3311,12 +4027,21 @@ fn test_e2e_edge_discovery() {
     let final_edges = common::parse_edges_count(&combined).unwrap_or(0);
 
     eprintln!("[EDGES] Final edge count: {}", final_edges);
-    eprintln!("[EDGES] Output sample: {}", combined.lines().rev().take(10).collect::<Vec<_>>().join("\n"));
+    eprintln!(
+        "[EDGES] Output sample: {}",
+        combined
+            .lines()
+            .rev()
+            .take(10)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
 
     // Verify edges are being discovered (should be > 0)
     assert!(
         final_edges > 0,
-        "Should discover some edges. Got 0. Output: {}", combined
+        "Should discover some edges. Got 0. Output: {}",
+        combined
     );
 }
 
@@ -3324,7 +4049,9 @@ fn test_e2e_edge_discovery() {
 #[test]
 #[ignore]
 fn test_e2e_corpus_growth() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3346,7 +4073,8 @@ fn test_e2e_corpus_growth() {
     // Should have generated some corpus entries
     assert!(
         corpus_count > 0,
-        "Corpus should grow as coverage is discovered. Got 0 files. Output: {}", combined
+        "Corpus should grow as coverage is discovered. Got 0 files. Output: {}",
+        combined
     );
 }
 
@@ -3354,7 +4082,9 @@ fn test_e2e_corpus_growth() {
 #[test]
 #[ignore]
 fn test_e2e_corpus_growth_30s() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3386,7 +4116,9 @@ fn test_e2e_corpus_growth_30s() {
     // Corpus should have grown
     assert!(
         final_count >= 1,
-        "Corpus should have entries after 30s. Got {}. Output: {}", final_count, combined
+        "Corpus should have entries after 30s. Got {}. Output: {}",
+        final_count,
+        combined
     );
 }
 
@@ -3398,7 +4130,9 @@ fn test_e2e_corpus_growth_30s() {
 #[test]
 #[ignore]
 fn test_e2e_multicore_no_corpus_duplication() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_single = temp.path().join("corpus_single");
@@ -3432,7 +4166,10 @@ fn test_e2e_multicore_no_corpus_duplication() {
     let combined = format!("{}\n{}", stdout, stderr);
     let multi_count = common::count_corpus_files(&corpus_multi);
 
-    eprintln!("[DUPLICATION] Single-core corpus: {}, Multi-core corpus: {}", single_count, multi_count);
+    eprintln!(
+        "[DUPLICATION] Single-core corpus: {}, Multi-core corpus: {}",
+        single_count, multi_count
+    );
 
     // Multi-core shouldn't have drastically more entries than single-core
     // (The bug caused N× inflation where N = number of workers)
@@ -3445,7 +4182,10 @@ fn test_e2e_multicore_no_corpus_duplication() {
             ratio < 4.0 || multi_count < 50,
             "Multi-core corpus inflation detected: {}× ({} vs {}). \
              This may indicate SharedBitmapFeedback regression. Output: {}",
-            ratio, multi_count, single_count, combined
+            ratio,
+            multi_count,
+            single_count,
+            combined
         );
     }
 }
@@ -3454,7 +4194,9 @@ fn test_e2e_multicore_no_corpus_duplication() {
 #[test]
 #[ignore]
 fn test_e2e_multicore_throughput() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3470,7 +4212,9 @@ fn test_e2e_multicore_throughput() {
     );
 
     if stderr == "TIMEOUT" {
-        eprintln!("[MULTICORE-THROUGHPUT] Hard timeout reached - multicore exit may need investigation");
+        eprintln!(
+            "[MULTICORE-THROUGHPUT] Hard timeout reached - multicore exit may need investigation"
+        );
         return;
     }
 
@@ -3487,7 +4231,9 @@ fn test_e2e_multicore_throughput() {
         assert!(
             rate > 10.0,
             "Multi-core throughput too low: {:.1} exec/sec. \
-             May indicate contention issues. Output: {}", rate, combined
+             May indicate contention issues. Output: {}",
+            rate,
+            combined
         );
     }
 }
@@ -3500,7 +4246,9 @@ fn test_e2e_multicore_throughput() {
 #[test]
 #[ignore]
 fn test_e2e_stop_on_crash() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3510,7 +4258,7 @@ fn test_e2e_stop_on_crash() {
 
     // Run with stop-on-crash (should exit early if crash found)
     let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_TIMEOUT_SECS", "120"),  // Long timeout
+        ("FUZZ_TIMEOUT_SECS", "120"), // Long timeout
         ("FUZZ_STOP_ON_CRASH", "1"),
         ("FUZZ_CORPUS_OUT", corpus_out.to_str().unwrap()),
         ("FUZZ_CRASHES_DIR", crashes_dir.to_str().unwrap()),
@@ -3521,21 +4269,27 @@ fn test_e2e_stop_on_crash() {
 
     let crash_files = common::count_crash_files(&crashes_dir);
 
-    eprintln!("[STOP-ON-CRASH] Elapsed: {}s, Crashes: {}", elapsed.as_secs(), crash_files);
+    eprintln!(
+        "[STOP-ON-CRASH] Elapsed: {}s, Crashes: {}",
+        elapsed.as_secs(),
+        crash_files
+    );
 
     if crash_files > 0 {
         // If crash found, should have stopped early (< 120s)
         assert!(
             elapsed.as_secs() < 100,
             "Stop-on-crash should exit after finding crash. Took {}s. Output: {}",
-            elapsed.as_secs(), combined
+            elapsed.as_secs(),
+            combined
         );
 
         // Should only have 1 crash (stopped after first)
         assert!(
-            crash_files <= 2,  // Allow small race condition
+            crash_files <= 2, // Allow small race condition
             "Stop-on-crash should stop after first crash. Got {} crashes. Output: {}",
-            crash_files, combined
+            crash_files,
+            combined
         );
     } else {
         eprintln!("[STOP-ON-CRASH] No crash found in 120s - bug may be hard to trigger");
@@ -3546,7 +4300,9 @@ fn test_e2e_stop_on_crash() {
 #[test]
 #[ignore]
 fn test_e2e_stop_on_crash_multicore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3564,7 +4320,7 @@ fn test_e2e_stop_on_crash_multicore() {
             ("FUZZ_CORPUS_OUT", corpus_out.to_str().unwrap()),
             ("FUZZ_CRASHES_DIR", crashes_dir.to_str().unwrap()),
         ],
-        90,  // Hard timeout - should exit much sooner if stop-on-crash works
+        90, // Hard timeout - should exit much sooner if stop-on-crash works
     );
 
     let elapsed = start.elapsed();
@@ -3585,7 +4341,11 @@ fn test_e2e_stop_on_crash_multicore() {
 
     let crash_files = common::count_crash_files(&crashes_dir);
 
-    eprintln!("[STOP-ON-CRASH-MC] Elapsed: {}s, Crashes: {}", elapsed.as_secs(), crash_files);
+    eprintln!(
+        "[STOP-ON-CRASH-MC] Elapsed: {}s, Crashes: {}",
+        elapsed.as_secs(),
+        crash_files
+    );
 
     if crash_files > 0 {
         // If crash found, should have stopped early (< 60s)
@@ -3598,7 +4358,8 @@ fn test_e2e_stop_on_crash_multicore() {
         // Should show the signaling message
         assert!(
             combined.contains("signaling stop") || combined.contains("Stop signal"),
-            "Should show stop signal message. Output: {}", combined
+            "Should show stop signal message. Output: {}",
+            combined
         );
     } else {
         eprintln!("[STOP-ON-CRASH-MC] No crash found within timeout - test-program bug may be hard to trigger");
@@ -3609,7 +4370,9 @@ fn test_e2e_stop_on_crash_multicore() {
 #[test]
 #[ignore]
 fn test_e2e_stop_on_crash_stateful() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let crashes_dir = temp.path().join("crashes");
@@ -3630,24 +4393,32 @@ fn test_e2e_stop_on_crash_stateful() {
     let combined = format!("{}\n{}", stdout, stderr);
 
     if stderr == "TIMEOUT" {
-        eprintln!("[STOP-ON-CRASH-STATEFUL] Hard timeout reached - stop-on-crash may not be working");
+        eprintln!(
+            "[STOP-ON-CRASH-STATEFUL] Hard timeout reached - stop-on-crash may not be working"
+        );
         return;
     }
 
     let crash_files = common::count_crash_files(&crashes_dir);
 
-    eprintln!("[STOP-ON-CRASH-STATEFUL] Elapsed: {}s, Crashes: {}", elapsed.as_secs(), crash_files);
+    eprintln!(
+        "[STOP-ON-CRASH-STATEFUL] Elapsed: {}s, Crashes: {}",
+        elapsed.as_secs(),
+        crash_files
+    );
 
     if crash_files > 0 {
         assert!(
             elapsed.as_secs() < 100,
             "Stateful stop-on-crash should exit after finding crash. Took {}s. Output: {}",
-            elapsed.as_secs(), combined
+            elapsed.as_secs(),
+            combined
         );
 
         assert!(
             combined.contains("stop-on-crash") || combined.contains("signaling stop"),
-            "Should show stop-on-crash message. Output: {}", combined
+            "Should show stop-on-crash message. Output: {}",
+            combined
         );
     } else {
         eprintln!("[STOP-ON-CRASH-STATEFUL] No crash found within timeout");
@@ -3658,7 +4429,9 @@ fn test_e2e_stop_on_crash_stateful() {
 #[test]
 #[ignore]
 fn test_e2e_stop_on_crash_stateful_multicore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let crashes_dir = temp.path().join("crashes");
@@ -3687,25 +4460,32 @@ fn test_e2e_stop_on_crash_stateful_multicore() {
 
     let crash_files = common::count_crash_files(&crashes_dir);
 
-    eprintln!("[STOP-ON-CRASH-STATEFUL-MC] Elapsed: {}s, Crashes: {}", elapsed.as_secs(), crash_files);
+    eprintln!(
+        "[STOP-ON-CRASH-STATEFUL-MC] Elapsed: {}s, Crashes: {}",
+        elapsed.as_secs(),
+        crash_files
+    );
 
     if crash_files > 0 {
         assert!(
             elapsed.as_secs() < 100,
             "Stateful multicore stop-on-crash should exit quickly. Took {}s. Output: {}",
-            elapsed.as_secs(), combined
+            elapsed.as_secs(),
+            combined
         );
 
         assert!(
             combined.contains("stop-on-crash") || combined.contains("signaling stop"),
-            "Should show stop-on-crash message. Output: {}", combined
+            "Should show stop-on-crash message. Output: {}",
+            combined
         );
 
         // Should have minimal crashes (stopped after first)
         assert!(
-            crash_files <= 3,  // Allow small race condition with multiple workers
+            crash_files <= 3, // Allow small race condition with multiple workers
             "Stop-on-crash should stop after first crash. Got {} crashes. Output: {}",
-            crash_files, combined
+            crash_files,
+            combined
         );
     } else {
         eprintln!("[STOP-ON-CRASH-STATEFUL-MC] No crash found within timeout");
@@ -3720,7 +4500,9 @@ fn test_e2e_stop_on_crash_stateful_multicore() {
 #[test]
 #[ignore]
 fn test_e2e_replay_shows_violation_marker() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3744,7 +4526,10 @@ fn test_e2e_replay_shows_violation_marker() {
 
     // Replay the crash
     let (_, input_path) = &crashes[0];
-    eprintln!("[VIOLATION-MARKER] Replaying crash: {}", input_path.display());
+    eprintln!(
+        "[VIOLATION-MARKER] Replaying crash: {}",
+        input_path.display()
+    );
 
     let (stdout, stderr, _) = common::run_test_program_fuzz(&[
         ("FUZZ_INPUT_FILE", input_path.to_str().unwrap()),
@@ -3757,18 +4542,24 @@ fn test_e2e_replay_shows_violation_marker() {
 
     // Verify replay executes and shows the input
     assert!(
-        combined.contains("[REPLAY]") || combined.contains("Loading input") || combined.contains("Replay"),
-        "Replay should indicate it's in replay mode. Output: {}", combined
+        combined.contains("[REPLAY]")
+            || combined.contains("Loading input")
+            || combined.contains("Replay"),
+        "Replay should indicate it's in replay mode. Output: {}",
+        combined
     );
 
     // Verify the crash is reproduced (panic or violation message)
     let has_panic = combined.contains("panicked at");
     let has_violation = combined.to_lowercase().contains("violation");
-    let has_assertion = combined.contains("assertion") || combined.contains("stake-time") || combined.contains("earned");
+    let has_assertion = combined.contains("assertion")
+        || combined.contains("stake-time")
+        || combined.contains("earned");
 
     assert!(
         has_panic || has_violation || has_assertion,
-        "Replay should reproduce the crash (show panic or violation). Output: {}", combined
+        "Replay should reproduce the crash (show panic or violation). Output: {}",
+        combined
     );
 
     eprintln!("[VIOLATION-MARKER] Crash successfully reproduced via replay");
@@ -3778,7 +4569,9 @@ fn test_e2e_replay_shows_violation_marker() {
 #[test]
 #[ignore]
 fn test_e2e_replay_executes_input() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3799,25 +4592,32 @@ fn test_e2e_replay_executes_input() {
 
     let (_, input_path) = &crashes[0];
     let input_size = fs::metadata(&input_path).map(|m| m.len()).unwrap_or(0);
-    eprintln!("[REPLAY-EXEC] Crash input file: {} ({} bytes)", input_path.display(), input_size);
+    eprintln!(
+        "[REPLAY-EXEC] Crash input file: {} ({} bytes)",
+        input_path.display(),
+        input_size
+    );
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", input_path.to_str().unwrap()),
-    ]);
+    let (stdout, stderr, _) =
+        common::run_test_program_fuzz(&[("FUZZ_INPUT_FILE", input_path.to_str().unwrap())]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
     // Verify replay mode is indicated
     assert!(
-        combined.contains("[REPLAY]") || combined.contains("Loading input") ||
-        combined.contains("bytes") || combined.contains("Executing"),
-        "Replay should show loading/executing the input. Output: {}", combined
+        combined.contains("[REPLAY]")
+            || combined.contains("Loading input")
+            || combined.contains("bytes")
+            || combined.contains("Executing"),
+        "Replay should show loading/executing the input. Output: {}",
+        combined
     );
 
     // Verify something happened (either panic or successful execution info)
     assert!(
         combined.contains("panicked") || combined.contains("thread") || combined.contains("test"),
-        "Replay should execute the test. Output: {}", combined
+        "Replay should execute the test. Output: {}",
+        combined
     );
 
     eprintln!("[REPLAY-EXEC] Replay completed");
@@ -3827,7 +4627,9 @@ fn test_e2e_replay_executes_input() {
 #[test]
 #[ignore]
 fn test_e2e_crash_stops_fuzzing() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3848,14 +4650,19 @@ fn test_e2e_crash_stops_fuzzing() {
 
     let crashes = common::find_crash_files(&crashes_dir);
 
-    eprintln!("[CRASH-STOPS] Elapsed: {}s, Crashes: {}", elapsed.as_secs(), crashes.len());
+    eprintln!(
+        "[CRASH-STOPS] Elapsed: {}s, Crashes: {}",
+        elapsed.as_secs(),
+        crashes.len()
+    );
 
     if !crashes.is_empty() {
         // If crash found, should have stopped before full timeout
         assert!(
             elapsed.as_secs() < 55,
             "Should stop early when crash found with --stop-on-crash. Took {}s. Output: {}",
-            elapsed.as_secs(), combined
+            elapsed.as_secs(),
+            combined
         );
         eprintln!("[CRASH-STOPS] Correctly stopped after finding crash");
     } else {
@@ -3871,7 +4678,9 @@ fn test_e2e_crash_stops_fuzzing() {
 #[test]
 #[ignore]
 fn test_e2e_crash_files_created() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -3906,7 +4715,8 @@ fn test_e2e_crash_files_created() {
 
     assert!(
         !crashes.is_empty(),
-        "Should have crash files when crash was detected. Output: {}", combined
+        "Should have crash files when crash was detected. Output: {}",
+        combined
     );
 
     // Verify crash input file is readable
@@ -3914,10 +4724,14 @@ fn test_e2e_crash_files_created() {
     let input_content = fs::read(input_path).unwrap();
     assert!(
         !input_content.is_empty(),
-        "Crash input file should not be empty: {}", input_path.display()
+        "Crash input file should not be empty: {}",
+        input_path.display()
     );
 
-    eprintln!("[CRASH-FILES] Crash input size: {} bytes", input_content.len());
+    eprintln!(
+        "[CRASH-FILES] Crash input size: {} bytes",
+        input_content.len()
+    );
 }
 
 // =============================================================================
@@ -3928,7 +4742,9 @@ fn test_e2e_crash_files_created() {
 #[test]
 #[ignore]
 fn test_e2e_dry_run_with_coverage() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -3948,7 +4764,8 @@ fn test_e2e_dry_run_with_coverage() {
     // Should complete without error (dry-run may not write coverage but should run)
     assert!(
         success || combined.to_lowercase().contains("dry") || combined.contains("iteration"),
-        "Dry-run with coverage should complete. Output: {}", combined
+        "Dry-run with coverage should complete. Output: {}",
+        combined
     );
 }
 
@@ -3956,7 +4773,9 @@ fn test_e2e_dry_run_with_coverage() {
 #[test]
 #[ignore]
 fn test_e2e_dry_run_with_corpus() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -3973,8 +4792,11 @@ fn test_e2e_dry_run_with_corpus() {
 
     // Should load corpus and run one iteration
     assert!(
-        success || combined.to_lowercase().contains("dry") || combined.to_lowercase().contains("iteration"),
-        "Dry-run with corpus should complete. Output: {}", combined
+        success
+            || combined.to_lowercase().contains("dry")
+            || combined.to_lowercase().contains("iteration"),
+        "Dry-run with corpus should complete. Output: {}",
+        combined
     );
 }
 
@@ -3986,7 +4808,9 @@ fn test_e2e_dry_run_with_corpus() {
 #[test]
 #[ignore]
 fn test_e2e_coverage_percentage_reasonable() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4009,10 +4833,14 @@ fn test_e2e_coverage_percentage_reasonable() {
             // Extract percentage value
             if let Some(pct_pos) = line.find('%') {
                 let before = &line[..pct_pos];
-                let pct_str: String = before.chars().rev()
+                let pct_str: String = before
+                    .chars()
+                    .rev()
                     .take_while(|c| c.is_ascii_digit() || *c == '.')
                     .collect::<String>()
-                    .chars().rev().collect();
+                    .chars()
+                    .rev()
+                    .collect();
 
                 if let Ok(pct) = pct_str.parse::<f64>() {
                     found_percentage = true;
@@ -4031,7 +4859,8 @@ fn test_e2e_coverage_percentage_reasonable() {
 
     assert!(
         found_percentage || has_edges,
-        "Should have coverage stats in output. Output: {}", combined
+        "Should have coverage stats in output. Output: {}",
+        combined
     );
 
     // The max percentage should be reasonable (> 0 after 15s of fuzzing)
@@ -4039,7 +4868,8 @@ fn test_e2e_coverage_percentage_reasonable() {
     if max_percentage > 0.0 {
         assert!(
             max_percentage < 100.0,
-            "Coverage should not be 100%. Got {}%", max_percentage
+            "Coverage should not be 100%. Got {}%",
+            max_percentage
         );
         eprintln!("[COVERAGE-PCT] Coverage is reasonable: {}%", max_percentage);
     } else if has_edges {
@@ -4055,7 +4885,9 @@ fn test_e2e_coverage_percentage_reasonable() {
 #[test]
 #[ignore]
 fn test_e2e_multiple_crashes_unique_names() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4080,22 +4912,34 @@ fn test_e2e_multiple_crashes_unique_names() {
         let mut names: Vec<String> = Vec::new();
         for (meta_path, input_path) in &crashes {
             let meta_name = meta_path.file_name().unwrap().to_string_lossy().to_string();
-            let input_name = input_path.file_name().unwrap().to_string_lossy().to_string();
+            let input_name = input_path
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .to_string();
 
             eprintln!("[MULTI-CRASH] Crash: {} / {}", input_name, meta_name);
 
             assert!(
                 !names.contains(&input_name),
-                "Duplicate crash name found: {}. All crashes: {:?}", input_name, names
+                "Duplicate crash name found: {}. All crashes: {:?}",
+                input_name,
+                names
             );
             names.push(input_name);
         }
 
-        eprintln!("[MULTI-CRASH] All {} crashes have unique names", crashes.len());
+        eprintln!(
+            "[MULTI-CRASH] All {} crashes have unique names",
+            crashes.len()
+        );
     } else if crashes.len() == 1 {
         eprintln!("[MULTI-CRASH] Only 1 crash found - can't test uniqueness");
     } else {
-        eprintln!("[MULTI-CRASH] No crashes found in 60s. Output: {}", combined);
+        eprintln!(
+            "[MULTI-CRASH] No crashes found in 60s. Output: {}",
+            combined
+        );
     }
 }
 
@@ -4107,13 +4951,13 @@ fn test_e2e_multiple_crashes_unique_names() {
 #[test]
 #[ignore]
 fn test_e2e_timeout_zero_immediate_exit() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let start = std::time::Instant::now();
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_TIMEOUT_SECS", "0"),
-    ]);
+    let (stdout, stderr, _) = common::run_test_program_fuzz(&[("FUZZ_TIMEOUT_SECS", "0")]);
 
     let elapsed = start.elapsed();
     let combined = format!("{}\n{}", stdout, stderr);
@@ -4121,7 +4965,9 @@ fn test_e2e_timeout_zero_immediate_exit() {
     // With timeout=0, should exit very quickly (within a few seconds at most)
     assert!(
         elapsed.as_secs() <= 5,
-        "Timeout=0 should exit immediately. Took {}s. Output: {}", elapsed.as_secs(), combined
+        "Timeout=0 should exit immediately. Took {}s. Output: {}",
+        elapsed.as_secs(),
+        combined
     );
 
     eprintln!("[TIMEOUT-0] Elapsed: {}ms", elapsed.as_millis());
@@ -4131,13 +4977,13 @@ fn test_e2e_timeout_zero_immediate_exit() {
 #[test]
 #[ignore]
 fn test_e2e_timeout_very_short() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let start = std::time::Instant::now();
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_TIMEOUT_SECS", "1"),
-    ]);
+    let (stdout, stderr, _) = common::run_test_program_fuzz(&[("FUZZ_TIMEOUT_SECS", "1")]);
 
     let elapsed = start.elapsed();
     let combined = format!("{}\n{}", stdout, stderr);
@@ -4145,7 +4991,9 @@ fn test_e2e_timeout_very_short() {
     // Should exit within reasonable time (1s timeout + overhead)
     assert!(
         elapsed.as_secs() <= 10,
-        "Timeout=1s should exit quickly. Took {}s. Output: {}", elapsed.as_secs(), combined
+        "Timeout=1s should exit quickly. Took {}s. Output: {}",
+        elapsed.as_secs(),
+        combined
     );
 
     eprintln!("[TIMEOUT-1s] Elapsed: {}s", elapsed.as_secs());
@@ -4159,7 +5007,9 @@ fn test_e2e_timeout_very_short() {
 #[test]
 #[ignore]
 fn test_e2e_crash_metadata_complete() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4191,45 +5041,52 @@ fn test_e2e_crash_metadata_complete() {
         return;
     }
 
-    eprintln!("[META-COMPLETE] Found {} crash files, validating metadata...", crashes.len());
+    eprintln!(
+        "[META-COMPLETE] Found {} crash files, validating metadata...",
+        crashes.len()
+    );
 
     // Read and validate metadata file
     let (meta_path, input_path) = &crashes[0];
-    let meta_content = fs::read_to_string(meta_path)
-        .expect(&format!("Failed to read metadata file: {}", meta_path.display()));
+    let meta_content = fs::read_to_string(meta_path).expect(&format!(
+        "Failed to read metadata file: {}",
+        meta_path.display()
+    ));
 
     // Parse JSON
     let json: serde_json::Value = serde_json::from_str(&meta_content)
         .expect(&format!("Invalid JSON in metadata: {}", meta_content));
 
-    eprintln!("[META-COMPLETE] Metadata JSON: {}", serde_json::to_string_pretty(&json).unwrap());
+    eprintln!(
+        "[META-COMPLETE] Metadata JSON: {}",
+        serde_json::to_string_pretty(&json).unwrap()
+    );
 
     // === Verify test_name ===
-    let test_name = json.get("test_name")
+    let test_name = json
+        .get("test_name")
         .expect("Missing 'test_name' field in metadata")
         .as_str()
         .expect("'test_name' should be a string");
-    assert!(
-        !test_name.is_empty(),
-        "test_name should not be empty"
-    );
+    assert!(!test_name.is_empty(), "test_name should not be empty");
     eprintln!("[META-COMPLETE] test_name: {}", test_name);
 
     // === Verify timestamp ===
-    let timestamp = json.get("timestamp").expect("Missing 'timestamp' field in metadata");
+    let timestamp = json
+        .get("timestamp")
+        .expect("Missing 'timestamp' field in metadata");
     if let Some(ts_str) = timestamp.as_str() {
         // ISO 8601 format: "2026-02-06T04:27:52Z"
-        assert!(
-            ts_str.len() >= 10,
-            "timestamp string too short: {}", ts_str
-        );
+        assert!(ts_str.len() >= 10, "timestamp string too short: {}", ts_str);
         eprintln!("[META-COMPLETE] timestamp (string): {}", ts_str);
     } else if let Some(ts_num) = timestamp.as_u64() {
         // Unix timestamp: should be within test run window (with some buffer)
         assert!(
             ts_num >= start_time.saturating_sub(60) && ts_num <= end_time + 60,
             "timestamp {} should be within test run window ({} - {})",
-            ts_num, start_time, end_time
+            ts_num,
+            start_time,
+            end_time
         );
         eprintln!("[META-COMPLETE] timestamp (unix): {}", ts_num);
     } else {
@@ -4237,7 +5094,8 @@ fn test_e2e_crash_metadata_complete() {
     }
 
     // === Verify iteration ===
-    let iteration = json.get("iteration")
+    let iteration = json
+        .get("iteration")
         .expect("Missing 'iteration' field in metadata")
         .as_u64()
         .expect("'iteration' should be a number");
@@ -4253,46 +5111,61 @@ fn test_e2e_crash_metadata_complete() {
     }
 
     // === Verify actions array ===
-    let actions = json.get("actions")
+    let actions = json
+        .get("actions")
         .expect("Missing 'actions' field in metadata")
         .as_array()
         .expect("'actions' should be an array");
-    assert!(!actions.is_empty(), "actions array should not be empty for crash");
+    assert!(
+        !actions.is_empty(),
+        "actions array should not be empty for crash"
+    );
     eprintln!("[META-COMPLETE] actions count: {}", actions.len());
 
     // Verify each action structure
     for (i, action) in actions.iter().enumerate() {
         // name: should be a string
-        let name = action.get("name")
+        let name = action
+            .get("name")
             .unwrap_or_else(|| panic!("Action {} missing 'name' field", i))
             .as_str()
             .unwrap_or_else(|| panic!("Action {} 'name' should be string", i));
-        assert!(
-            !name.is_empty(),
-            "Action {} name should not be empty", i
-        );
+        assert!(!name.is_empty(), "Action {} name should not be empty", i);
 
         // params: should be an object
-        let params = action.get("params")
+        let params = action
+            .get("params")
             .unwrap_or_else(|| panic!("Action {} missing 'params' field", i));
         assert!(
             params.is_object(),
-            "Action {} 'params' should be object, got {:?}", i, params
+            "Action {} 'params' should be object, got {:?}",
+            i,
+            params
         );
 
         // success: should be boolean
-        let success = action.get("success")
+        let success = action
+            .get("success")
             .unwrap_or_else(|| panic!("Action {} missing 'success' field", i));
         assert!(
             success.is_boolean(),
-            "Action {} 'success' should be boolean, got {:?}", i, success
+            "Action {} 'success' should be boolean, got {:?}",
+            i,
+            success
         );
 
-        eprintln!("[META-COMPLETE] Action {}: name={}, success={}", i, name, success);
+        eprintln!(
+            "[META-COMPLETE] Action {}: name={}, success={}",
+            i, name, success
+        );
     }
 
     // === Verify input bytes file exists and is non-empty ===
-    assert!(input_path.exists(), "Input bytes file should exist: {}", input_path.display());
+    assert!(
+        input_path.exists(),
+        "Input bytes file should exist: {}",
+        input_path.display()
+    );
     let input_bytes = fs::read(input_path).unwrap();
     assert!(!input_bytes.is_empty(), "Input bytes should not be empty");
     eprintln!("[META-COMPLETE] Input bytes: {} bytes", input_bytes.len());
@@ -4304,7 +5177,9 @@ fn test_e2e_crash_metadata_complete() {
 #[test]
 #[ignore]
 fn test_e2e_crash_metadata_actions_array() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let crashes_dir = temp.path().join("crashes");
@@ -4328,11 +5203,16 @@ fn test_e2e_crash_metadata_actions_array() {
     let actions = json.get("actions").unwrap().as_array().unwrap();
 
     // At least one action should have succeeded before the crash
-    let successful_actions: Vec<_> = actions.iter()
+    let successful_actions: Vec<_> = actions
+        .iter()
         .filter(|a| a.get("success").and_then(|s| s.as_bool()).unwrap_or(false))
         .collect();
 
-    eprintln!("[META-ACTIONS] {} total actions, {} successful", actions.len(), successful_actions.len());
+    eprintln!(
+        "[META-ACTIONS] {} total actions, {} successful",
+        actions.len(),
+        successful_actions.len()
+    );
 
     // Verify params are serializable (not empty objects for every action)
     let mut has_nonempty_params = false;
@@ -4340,8 +5220,11 @@ fn test_e2e_crash_metadata_actions_array() {
         if let Some(params) = action.get("params").and_then(|p| p.as_object()) {
             if !params.is_empty() {
                 has_nonempty_params = true;
-                eprintln!("[META-ACTIONS] Action '{}' params: {:?}",
-                    action.get("name").unwrap(), params);
+                eprintln!(
+                    "[META-ACTIONS] Action '{}' params: {:?}",
+                    action.get("name").unwrap(),
+                    params
+                );
             }
         }
     }
@@ -4350,7 +5233,8 @@ fn test_e2e_crash_metadata_actions_array() {
     if actions.len() > 1 {
         assert!(
             has_nonempty_params,
-            "Actions should have params. Actions: {:?}", actions
+            "Actions should have params. Actions: {:?}",
+            actions
         );
     }
 }
@@ -4363,7 +5247,9 @@ fn test_e2e_crash_metadata_actions_array() {
 #[test]
 #[ignore]
 fn test_e2e_multicore_4_cores() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4392,10 +5278,13 @@ fn test_e2e_multicore_4_cores() {
 
     // Verify multi-core mode was used
     assert!(
-        combined.contains("worker") || combined.contains("core") ||
-        combined.contains("parallel") || combined.contains("Launcher") ||
-        combined.contains("4"),
-        "Should indicate 4-core mode. Output: {}", combined
+        combined.contains("worker")
+            || combined.contains("core")
+            || combined.contains("parallel")
+            || combined.contains("Launcher")
+            || combined.contains("4"),
+        "Should indicate 4-core mode. Output: {}",
+        combined
     );
 
     // Verify coverage was discovered
@@ -4404,7 +5293,8 @@ fn test_e2e_multicore_4_cores() {
 
     assert!(
         edges > 0 || corpus_out.exists(),
-        "4-core mode should produce results. Output: {}", combined
+        "4-core mode should produce results. Output: {}",
+        combined
     );
 }
 
@@ -4412,7 +5302,9 @@ fn test_e2e_multicore_4_cores() {
 #[test]
 #[ignore]
 fn test_e2e_multicore_cores_greater_than_cpus() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4421,7 +5313,7 @@ fn test_e2e_multicore_cores_greater_than_cpus() {
     let (stdout, stderr, success) = common::run_test_program_fuzz_with_timeout(
         &[
             ("FUZZ_TIMEOUT_SECS", "5"),
-            ("FUZZ_CORES", "100"),  // More than typical CPU count
+            ("FUZZ_CORES", "100"), // More than typical CPU count
             ("FUZZ_CORPUS_OUT", corpus_out.to_str().unwrap()),
         ],
         30,
@@ -4439,7 +5331,8 @@ fn test_e2e_multicore_cores_greater_than_cpus() {
 
     // Handle expected Launcher failures with extreme core counts
     // LibAFL's shared memory infrastructure has limits on concurrent workers
-    if stderr == "TIMEOUT" || stderr.contains("Launcher failed") || stderr.contains("shmem socket") {
+    if stderr == "TIMEOUT" || stderr.contains("Launcher failed") || stderr.contains("shmem socket")
+    {
         // This is expected - LibAFL can't reliably handle 100 concurrent workers
         // The key is the fuzzer didn't crash in an unexpected way
         eprintln!("[CORES-100] Expected Launcher limitation with extreme core count");
@@ -4449,7 +5342,8 @@ fn test_e2e_multicore_cores_greater_than_cpus() {
     // If it didn't timeout/fail, verify it produced some output
     assert!(
         combined.contains("exec/sec") || combined.contains("Fuzzing") || !success,
-        "Should either succeed with output or fail gracefully. Output: {}", combined
+        "Should either succeed with output or fail gracefully. Output: {}",
+        combined
     );
 }
 
@@ -4457,7 +5351,9 @@ fn test_e2e_multicore_cores_greater_than_cpus() {
 #[test]
 #[ignore]
 fn test_e2e_multicore_all_workers_contribute() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4474,7 +5370,8 @@ fn test_e2e_multicore_all_workers_contribute() {
 
     // Handle multicore infrastructure failures gracefully
     // These can happen when running multiple multicore tests in sequence
-    if stderr == "TIMEOUT" || stderr.contains("Launcher failed") || stderr.contains("shmem socket") {
+    if stderr == "TIMEOUT" || stderr.contains("Launcher failed") || stderr.contains("shmem socket")
+    {
         eprintln!("[WORKERS-CONTRIBUTE] Hard timeout or Launcher failure - multicore infra issue");
         return;
     }
@@ -4488,7 +5385,10 @@ fn test_e2e_multicore_all_workers_contribute() {
         combined.contains("[0]") ||
         combined.contains("Launcher");
 
-    eprintln!("[WORKERS-CONTRIBUTE] Worker output detected: {}", has_worker_output);
+    eprintln!(
+        "[WORKERS-CONTRIBUTE] Worker output detected: {}",
+        has_worker_output
+    );
     eprintln!("[WORKERS-CONTRIBUTE] Output: {}", combined);
 
     // Verify corpus has entries (workers found coverage)
@@ -4497,7 +5397,8 @@ fn test_e2e_multicore_all_workers_contribute() {
 
     assert!(
         corpus_count > 0,
-        "Multi-core workers should contribute to corpus. Got 0 entries. Output: {}", combined
+        "Multi-core workers should contribute to corpus. Got 0 entries. Output: {}",
+        combined
     );
 }
 
@@ -4509,7 +5410,9 @@ fn test_e2e_multicore_all_workers_contribute() {
 #[test]
 #[ignore]
 fn test_e2e_replay_action_sequence_numbered() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let crashes_dir = temp.path().join("crashes");
@@ -4547,14 +5450,15 @@ fn test_e2e_replay_action_sequence_numbered() {
         combined.contains("SEQUENCE");
 
     // Or at least show action names
-    let has_actions = combined.contains("action_") ||
-        combined.contains("stake") ||
-        combined.contains("unstake") ||
-        combined.contains("claim");
+    let has_actions = combined.contains("action_")
+        || combined.contains("stake")
+        || combined.contains("unstake")
+        || combined.contains("claim");
 
     assert!(
         has_numbers || has_actions,
-        "Replay should show numbered or named action sequence. Output: {}", combined
+        "Replay should show numbered or named action sequence. Output: {}",
+        combined
     );
 }
 
@@ -4562,7 +5466,9 @@ fn test_e2e_replay_action_sequence_numbered() {
 #[test]
 #[ignore]
 fn test_e2e_replay_corrupted_input() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corrupted_input = temp.path().join("corrupted_crash");
@@ -4571,9 +5477,8 @@ fn test_e2e_replay_corrupted_input() {
     fs::write(&corrupted_input, &[0xFF, 0xFE, 0xFD, 0x00, 0x01, 0x02]).unwrap();
 
     // Try to replay corrupted input
-    let (stdout, stderr, success) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", corrupted_input.to_str().unwrap()),
-    ]);
+    let (stdout, stderr, success) =
+        common::run_test_program_fuzz(&[("FUZZ_INPUT_FILE", corrupted_input.to_str().unwrap())]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
@@ -4599,7 +5504,9 @@ fn test_e2e_replay_corrupted_input() {
 #[test]
 #[ignore]
 fn test_e2e_dry_run_no_crashes_created() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let crashes_dir = temp.path().join("crashes");
@@ -4622,7 +5529,8 @@ fn test_e2e_dry_run_no_crashes_created() {
     assert!(
         crash_count == 0,
         "Dry-run should not create crash files, but found {}. Output: {}",
-        crash_count, combined
+        crash_count,
+        combined
     );
 }
 
@@ -4630,7 +5538,9 @@ fn test_e2e_dry_run_no_crashes_created() {
 #[test]
 #[ignore]
 fn test_e2e_dry_run_loads_all_corpus_elements() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_dir = temp.path().join("corpus");
@@ -4663,10 +5573,12 @@ fn test_e2e_dry_run_loads_all_corpus_elements() {
     // 1. Report loading corpus entries OR
     // 2. Complete successfully and show dry-run message
     assert!(
-        success || combined.to_lowercase().contains("dry") ||
-        combined.to_lowercase().contains("corpus") ||
-        combined.to_lowercase().contains("load"),
-        "Dry-run should complete or report loading corpus. Output: {}", combined
+        success
+            || combined.to_lowercase().contains("dry")
+            || combined.to_lowercase().contains("corpus")
+            || combined.to_lowercase().contains("load"),
+        "Dry-run should complete or report loading corpus. Output: {}",
+        combined
     );
 }
 
@@ -4674,13 +5586,13 @@ fn test_e2e_dry_run_loads_all_corpus_elements() {
 #[test]
 #[ignore]
 fn test_e2e_dry_run_completes_quickly() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let start = std::time::Instant::now();
 
-    let (stdout, stderr, _) = common::run_test_program_fuzz(&[
-        ("FUZZ_DRY_RUN", "1"),
-    ]);
+    let (stdout, stderr, _) = common::run_test_program_fuzz(&[("FUZZ_DRY_RUN", "1")]);
 
     let elapsed = start.elapsed();
     let combined = format!("{}\n{}", stdout, stderr);
@@ -4690,7 +5602,9 @@ fn test_e2e_dry_run_completes_quickly() {
     // Dry-run should complete within a few seconds (not hang)
     assert!(
         elapsed.as_secs() < 30,
-        "Dry-run should complete quickly. Took {}s. Output: {}", elapsed.as_secs(), combined
+        "Dry-run should complete quickly. Took {}s. Output: {}",
+        elapsed.as_secs(),
+        combined
     );
 }
 
@@ -4702,7 +5616,9 @@ fn test_e2e_dry_run_completes_quickly() {
 #[test]
 #[ignore]
 fn test_e2e_cmin_preserves_coverage() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_full = temp.path().join("corpus_full");
@@ -4716,7 +5632,10 @@ fn test_e2e_cmin_preserves_coverage() {
 
     let full_count = common::count_corpus_files(&corpus_full);
     if full_count < 3 {
-        eprintln!("[CMIN-PRESERVES] Corpus too small ({}) - skipping", full_count);
+        eprintln!(
+            "[CMIN-PRESERVES] Corpus too small ({}) - skipping",
+            full_count
+        );
         return;
     }
 
@@ -4726,10 +5645,13 @@ fn test_e2e_cmin_preserves_coverage() {
         ("FUZZ_CORPUS_IN", corpus_full.to_str().unwrap()),
     ]);
 
-    let edges_full = common::parse_edges_count(&format!("{}\n{}", stdout_full, stderr_full))
-        .unwrap_or(0);
+    let edges_full =
+        common::parse_edges_count(&format!("{}\n{}", stdout_full, stderr_full)).unwrap_or(0);
 
-    eprintln!("[CMIN-PRESERVES] Full corpus: {} files, {} edges", full_count, edges_full);
+    eprintln!(
+        "[CMIN-PRESERVES] Full corpus: {} files, {} edges",
+        full_count, edges_full
+    );
 
     // Run cmin
     let (_, _, _) = common::run_test_program_fuzz(&[
@@ -4750,21 +5672,29 @@ fn test_e2e_cmin_preserves_coverage() {
         ("FUZZ_CORPUS_IN", corpus_min.to_str().unwrap()),
     ]);
 
-    let edges_min = common::parse_edges_count(&format!("{}\n{}", stdout_min, stderr_min))
-        .unwrap_or(0);
+    let edges_min =
+        common::parse_edges_count(&format!("{}\n{}", stdout_min, stderr_min)).unwrap_or(0);
 
-    eprintln!("[CMIN-PRESERVES] Minimized corpus: {} files, {} edges", min_count, edges_min);
+    eprintln!(
+        "[CMIN-PRESERVES] Minimized corpus: {} files, {} edges",
+        min_count, edges_min
+    );
 
     // Minimized corpus should preserve (approximately) the same coverage
     // Allow small variance due to timing/randomness
     if edges_full > 0 && edges_min > 0 {
         let coverage_ratio = edges_min as f64 / edges_full as f64;
-        eprintln!("[CMIN-PRESERVES] Coverage ratio: {:.2}%", coverage_ratio * 100.0);
+        eprintln!(
+            "[CMIN-PRESERVES] Coverage ratio: {:.2}%",
+            coverage_ratio * 100.0
+        );
 
         assert!(
-            coverage_ratio >= 0.9,  // Should preserve at least 90% of coverage
+            coverage_ratio >= 0.9, // Should preserve at least 90% of coverage
             "Cmin should preserve coverage. Full: {} edges, Min: {} edges (ratio: {:.2})",
-            edges_full, edges_min, coverage_ratio
+            edges_full,
+            edges_min,
+            coverage_ratio
         );
     }
 }
@@ -4773,7 +5703,9 @@ fn test_e2e_cmin_preserves_coverage() {
 #[test]
 #[ignore]
 fn test_e2e_cmin_single_file_corpus() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -4799,7 +5731,8 @@ fn test_e2e_cmin_single_file_corpus() {
     // Should either succeed or indicate single file
     assert!(
         success || combined.contains("1 input") || combined.contains("single"),
-        "Cmin should handle single-file corpus. Output: {}", combined
+        "Cmin should handle single-file corpus. Output: {}",
+        combined
     );
 
     // Output should have 0 or 1 files (can't reduce below 1 that provides coverage)
@@ -4807,7 +5740,8 @@ fn test_e2e_cmin_single_file_corpus() {
     assert!(
         out_count <= 1,
         "Cmin of single file should produce at most 1 file. Got {}. Output: {}",
-        out_count, combined
+        out_count,
+        combined
     );
 }
 
@@ -4815,7 +5749,9 @@ fn test_e2e_cmin_single_file_corpus() {
 #[test]
 #[ignore]
 fn test_e2e_cmin_overwrites_existing() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_in = temp.path().join("corpus_in");
@@ -4845,14 +5781,17 @@ fn test_e2e_cmin_overwrites_existing() {
     let old_file_exists = corpus_out.join("old_file_1").exists();
     let new_count = common::count_corpus_files(&corpus_out);
 
-    eprintln!("[CMIN-OVERWRITE] After cmin: {} files, old_file_1 exists: {}",
-        new_count, old_file_exists);
+    eprintln!(
+        "[CMIN-OVERWRITE] After cmin: {} files, old_file_1 exists: {}",
+        new_count, old_file_exists
+    );
 
     // Cmin should have handled the existing directory
     // (either cleared it or added to it)
     assert!(
         corpus_out.exists(),
-        "Corpus output should exist after cmin. Output: {}", combined
+        "Corpus output should exist after cmin. Output: {}",
+        combined
     );
 }
 
@@ -4864,7 +5803,9 @@ fn test_e2e_cmin_overwrites_existing() {
 #[test]
 #[ignore]
 fn test_e2e_coverage_disabled_multicore() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let fuzz_path = common::test_program_fuzz_path();
     let lcov_path = fuzz_path.join("coverage.lcov");
@@ -4880,7 +5821,7 @@ fn test_e2e_coverage_disabled_multicore() {
         &[
             ("FUZZ_TIMEOUT_SECS", "10"),
             ("FUZZ_CORES", "2"),
-            ("FUZZ_COVERAGE_ONLY", "1"),  // Try to enable coverage
+            ("FUZZ_COVERAGE_ONLY", "1"), // Try to enable coverage
             ("FUZZ_CORPUS_OUT", corpus_out.to_str().unwrap()),
         ],
         30,
@@ -4902,7 +5843,7 @@ fn test_e2e_coverage_disabled_multicore() {
     // For now, just document the behavior
     if lcov_exists {
         eprintln!("[COVERAGE-MULTICORE] Note: LCOV was created in multicore mode - this may be intentional or a bug");
-        let _ = fs::remove_file(&lcov_path);  // Clean up
+        let _ = fs::remove_file(&lcov_path); // Clean up
     } else {
         eprintln!("[COVERAGE-MULTICORE] LCOV correctly not created in multicore mode");
     }
@@ -4912,7 +5853,9 @@ fn test_e2e_coverage_disabled_multicore() {
 #[test]
 #[ignore]
 fn test_e2e_coverage_lcov_format_valid() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let fuzz_path = common::test_program_fuzz_path();
     let lcov_path = fuzz_path.join("coverage.lcov");
@@ -4946,13 +5889,16 @@ fn test_e2e_coverage_lcov_format_valid() {
     let has_da = content.contains("DA:");
     let has_end = content.contains("end_of_record");
 
-    eprintln!("[LCOV-FORMAT] TN: {}, SF: {}, DA: {}, end: {}",
-        has_tn, has_sf, has_da, has_end);
+    eprintln!(
+        "[LCOV-FORMAT] TN: {}, SF: {}, DA: {}, end: {}",
+        has_tn, has_sf, has_da, has_end
+    );
 
     // At minimum, should have source files and data
     assert!(
-        has_sf || content.contains("0x"),  // Either source files or PC addresses
-        "LCOV file should contain source or address info. Content: {}", &content[..content.len().min(500)]
+        has_sf || content.contains("0x"), // Either source files or PC addresses
+        "LCOV file should contain source or address info. Content: {}",
+        &content[..content.len().min(500)]
     );
 
     // Clean up
@@ -4969,7 +5915,9 @@ fn test_e2e_coverage_lcov_format_valid() {
 #[test]
 #[ignore]
 fn test_e2e_corpus_grows_over_time() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -4980,7 +5928,7 @@ fn test_e2e_corpus_grows_over_time() {
             ("FUZZ_TIMEOUT_SECS", "20"),
             ("FUZZ_CORPUS_OUT", corpus_out.to_str().unwrap()),
         ],
-        5,  // Sample every 5 seconds
+        5, // Sample every 5 seconds
         20,
     );
 
@@ -5007,7 +5955,10 @@ fn test_e2e_corpus_grows_over_time() {
     if corpus_counts.len() >= 2 {
         let first = corpus_counts.first().unwrap().1;
         let last = corpus_counts.last().unwrap().1;
-        eprintln!("[CORPUS-GROWTH] First sample: {}, Last sample: {}", first, last);
+        eprintln!(
+            "[CORPUS-GROWTH] First sample: {}, Last sample: {}",
+            first, last
+        );
         // Note: May not always grow if saturation reached quickly
     }
 }
@@ -5020,11 +5971,14 @@ fn test_e2e_corpus_grows_over_time() {
 #[test]
 #[ignore]
 fn test_e2e_input_nonexistent_file_error() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
-    let (stdout, stderr, success) = common::run_test_program_fuzz(&[
-        ("FUZZ_INPUT_FILE", "/nonexistent/path/that/does/not/exist/crash_file"),
-    ]);
+    let (stdout, stderr, success) = common::run_test_program_fuzz(&[(
+        "FUZZ_INPUT_FILE",
+        "/nonexistent/path/that/does/not/exist/crash_file",
+    )]);
 
     let combined = format!("{}\n{}", stdout, stderr);
 
@@ -5033,10 +5987,12 @@ fn test_e2e_input_nonexistent_file_error() {
 
     // Should fail with clear error message
     assert!(
-        !success || combined.to_lowercase().contains("error") ||
-        combined.to_lowercase().contains("not found") ||
-        combined.to_lowercase().contains("no such file"),
-        "Should report error for nonexistent input file. Output: {}", combined
+        !success
+            || combined.to_lowercase().contains("error")
+            || combined.to_lowercase().contains("not found")
+            || combined.to_lowercase().contains("no such file"),
+        "Should report error for nonexistent input file. Output: {}",
+        combined
     );
 }
 
@@ -5048,7 +6004,9 @@ fn test_e2e_input_nonexistent_file_error() {
 #[test]
 #[ignore]
 fn test_e2e_verbose_output() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let corpus_out = temp.path().join("corpus");
@@ -5087,7 +6045,9 @@ fn test_e2e_verbose_output() {
 #[test]
 #[ignore]
 fn test_e2e_inmemory_corpus_basic() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     // Run without any corpus directories - uses LibAFL's InMemoryCorpus
     let (stdout, stderr, success) = common::run_test_program_fuzz(&[
@@ -5100,13 +6060,15 @@ fn test_e2e_inmemory_corpus_basic() {
     // Should run successfully
     assert!(
         success || combined.contains("exec/sec") || combined.contains("Fuzzing"),
-        "In-memory corpus mode should run successfully. Output: {}", combined
+        "In-memory corpus mode should run successfully. Output: {}",
+        combined
     );
 
     // Should show execution stats
     assert!(
         combined.contains("exec/sec") || combined.contains("executions"),
-        "Should show execution statistics. Output: {}", combined
+        "Should show execution statistics. Output: {}",
+        combined
     );
 
     eprintln!("[INMEMORY-BASIC] Output: {}", combined);
@@ -5116,7 +6078,9 @@ fn test_e2e_inmemory_corpus_basic() {
 #[test]
 #[ignore]
 fn test_e2e_inmemory_corpus_finds_crashes() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
     let crashes_dir = temp.path().join("crashes");
@@ -5138,7 +6102,8 @@ fn test_e2e_inmemory_corpus_finds_crashes() {
 
     assert!(
         crash_count > 0,
-        "In-memory corpus mode should still find crashes. Output: {}", combined
+        "In-memory corpus mode should still find crashes. Output: {}",
+        combined
     );
 }
 
@@ -5146,7 +6111,9 @@ fn test_e2e_inmemory_corpus_finds_crashes() {
 #[test]
 #[ignore]
 fn test_e2e_inmemory_vs_ondisk_corpus() {
-    if !ensure_test_program_built() { return; }
+    if !ensure_test_program_built() {
+        return;
+    }
 
     let temp = TempDir::new().unwrap();
 
@@ -5188,14 +6155,22 @@ fn test_e2e_inmemory_vs_ondisk_corpus() {
         };
         assert!(
             ratio > 0.2,
-            "Performance difference should be reasonable. In-memory: {}, On-disk: {}", inmem, ondisk
+            "Performance difference should be reasonable. In-memory: {}, On-disk: {}",
+            inmem,
+            ondisk
         );
     }
 
     // Corpus should have entries for on-disk mode
     let corpus_count = common::count_corpus_files(&corpus_out);
-    eprintln!("[INMEM-VS-ONDISK] Corpus entries (on-disk): {}", corpus_count);
-    assert!(corpus_count > 0, "On-disk mode should create corpus entries");
+    eprintln!(
+        "[INMEM-VS-ONDISK] Corpus entries (on-disk): {}",
+        corpus_count
+    );
+    assert!(
+        corpus_count > 0,
+        "On-disk mode should create corpus entries"
+    );
 }
 
 /// Helper to extract execution count from fuzzer output
@@ -5209,8 +6184,10 @@ fn extract_exec_count(output: &str) -> Option<u64> {
                 // Find the last number in the string before "exec/sec"
                 let parts: Vec<&str> = before.split_whitespace().collect();
                 for part in parts.iter().rev() {
-                    if let Ok(n) = part.trim_matches(|c: char| !c.is_ascii_digit() && c != '.')
-                        .parse::<f64>() {
+                    if let Ok(n) = part
+                        .trim_matches(|c: char| !c.is_ascii_digit() && c != '.')
+                        .parse::<f64>()
+                    {
                         return Some((n * 10.0) as u64); // Multiply by ~timeout to estimate total
                     }
                 }
@@ -5219,10 +6196,14 @@ fn extract_exec_count(output: &str) -> Option<u64> {
         if line.contains("executions:") {
             if let Some(pos) = line.find("executions:") {
                 let after = &line[pos + 11..];
-                if let Ok(n) = after.trim().split_whitespace().next()
+                if let Ok(n) = after
+                    .trim()
+                    .split_whitespace()
+                    .next()
                     .unwrap_or("")
                     .trim_matches(|c: char| !c.is_ascii_digit())
-                    .parse::<u64>() {
+                    .parse::<u64>()
+                {
                     return Some(n);
                 }
             }
@@ -5244,7 +6225,11 @@ fn test_fuzz_pulse_in_all_modes() {
         ("crates/crucible-fuzz-macro/src/stateful.rs", "stateful"),
     ] {
         let content = fs::read_to_string(project_root().join(file)).unwrap();
-        assert!(content.contains("[FUZZ_PULSE]"), "{} should emit FUZZ_PULSE", label);
+        assert!(
+            content.contains("[FUZZ_PULSE]"),
+            "{} should emit FUZZ_PULSE",
+            label
+        );
     }
 }
 
@@ -5256,34 +6241,45 @@ fn test_fuzz_finding_in_all_modes() {
         ("crates/crucible-fuzz-macro/src/stateful.rs", "stateful"),
     ] {
         let content = fs::read_to_string(project_root().join(file)).unwrap();
-        assert!(content.contains("[FUZZ_FINDING]"), "{} should emit FUZZ_FINDING", label);
+        assert!(
+            content.contains("[FUZZ_FINDING]"),
+            "{} should emit FUZZ_FINDING",
+            label
+        );
     }
     // Replay mode uses [INVARIANT] instead of [FUZZ_FINDING]
-    let modes_content = fs::read_to_string(
-        project_root().join("crates/crucible-fuzz-macro/src/modes.rs")
-    ).unwrap();
-    assert!(modes_content.contains("[INVARIANT]"), "modes should emit INVARIANT for replay");
+    let modes_content =
+        fs::read_to_string(project_root().join("crates/crucible-fuzz-macro/src/modes.rs")).unwrap();
+    assert!(
+        modes_content.contains("[INVARIANT]"),
+        "modes should emit INVARIANT for replay"
+    );
 }
 
 #[test]
 fn test_did_not_reproduce_string() {
-    let content = fs::read_to_string(
-        project_root().join("crates/crucible-fuzz-macro/src/modes.rs")
-    ).unwrap();
+    let content =
+        fs::read_to_string(project_root().join("crates/crucible-fuzz-macro/src/modes.rs")).unwrap();
     assert!(content.contains(r#"eprintln!("did not reproduce")"#));
 }
 
 #[test]
 fn test_memory_reporting() {
     // Verify getrusage is used for memory reporting
-    let content = fs::read_to_string(
-        project_root().join("crates/crucible-fuzz-macro/src/codegen.rs")
-    ).unwrap();
-    assert!(content.contains("getrusage"), "codegen should use getrusage for memory");
-    let content = fs::read_to_string(
-        project_root().join("crates/crucible-fuzz-macro/src/stateful.rs")
-    ).unwrap();
-    assert!(content.contains("getrusage"), "stateful should use getrusage for memory");
+    let content =
+        fs::read_to_string(project_root().join("crates/crucible-fuzz-macro/src/codegen.rs"))
+            .unwrap();
+    assert!(
+        content.contains("getrusage"),
+        "codegen should use getrusage for memory"
+    );
+    let content =
+        fs::read_to_string(project_root().join("crates/crucible-fuzz-macro/src/stateful.rs"))
+            .unwrap();
+    assert!(
+        content.contains("getrusage"),
+        "stateful should use getrusage for memory"
+    );
 }
 
 #[test]
@@ -5291,7 +6287,11 @@ fn test_show_crashes_dir_nested() {
     ensure_cli_built();
     let temp = TempDir::new().unwrap();
     // Create fuzz dir structure for "." auto-detection
-    fs::write(temp.path().join("Cargo.toml"), "[package]\nname = \"test\"\nversion = \"0.1.0\"").unwrap();
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"",
+    )
+    .unwrap();
     fs::create_dir_all(temp.path().join("src")).unwrap();
     fs::write(temp.path().join("src/main.rs"), "fn main() {}").unwrap();
     // Create nested layout: crashes_dir/test_name/crash_file
@@ -5302,11 +6302,21 @@ fn test_show_crashes_dir_nested() {
     ).unwrap();
     fs::write(test_dir.join("crash_0000000000000001"), b"test").unwrap();
 
-    let output = run_crucible_in(temp.path(), &[
-        "show", ".", "--crashes-dir", temp.path().join("my_crashes").to_str().unwrap()
-    ]);
+    let output = run_crucible_in(
+        temp.path(),
+        &[
+            "show",
+            ".",
+            "--crashes-dir",
+            temp.path().join("my_crashes").to_str().unwrap(),
+        ],
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("crash_0000000000000001"), "should list crash from custom dir, got: {}", stdout);
+    assert!(
+        stdout.contains("crash_0000000000000001"),
+        "should list crash from custom dir, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -5314,7 +6324,11 @@ fn test_show_crashes_dir_flat() {
     ensure_cli_built();
     let temp = TempDir::new().unwrap();
     // Create fuzz dir structure for "." auto-detection
-    fs::write(temp.path().join("Cargo.toml"), "[package]\nname = \"test\"\nversion = \"0.1.0\"").unwrap();
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"",
+    )
+    .unwrap();
     fs::create_dir_all(temp.path().join("src")).unwrap();
     fs::write(temp.path().join("src/main.rs"), "fn main() {}").unwrap();
     // Create flat layout: crashes_dir/crash_file (no test subdirectory)
@@ -5325,11 +6339,16 @@ fn test_show_crashes_dir_flat() {
     ).unwrap();
     fs::write(crashes.join("crash_flat_001"), b"test").unwrap();
 
-    let output = run_crucible_in(temp.path(), &[
-        "show", ".", "--crashes-dir", crashes.to_str().unwrap()
-    ]);
+    let output = run_crucible_in(
+        temp.path(),
+        &["show", ".", "--crashes-dir", crashes.to_str().unwrap()],
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("crash_flat_001"), "should list flat crash, got: {}", stdout);
+    assert!(
+        stdout.contains("crash_flat_001"),
+        "should list flat crash, got: {}",
+        stdout
+    );
 }
 
 #[test]
@@ -5337,7 +6356,11 @@ fn test_show_crash_metadata_from_custom_dir() {
     ensure_cli_built();
     let temp = TempDir::new().unwrap();
     // Create fuzz dir structure for "." auto-detection
-    fs::write(temp.path().join("Cargo.toml"), "[package]\nname = \"test\"\nversion = \"0.1.0\"").unwrap();
+    fs::write(
+        temp.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"",
+    )
+    .unwrap();
     fs::create_dir_all(temp.path().join("src")).unwrap();
     fs::write(temp.path().join("src/main.rs"), "fn main() {}").unwrap();
     let crashes = temp.path().join("output");
@@ -5346,29 +6369,58 @@ fn test_show_crash_metadata_from_custom_dir() {
         r#"{"test_name":"invariant_test","timestamp":"2026-03-12T00:00:00Z","iteration":99,"actions":[{"name":"action_withdraw","params":{"user":0},"success":false}]}"#
     ).unwrap();
 
-    let output = run_crucible_in(temp.path(), &[
-        "show", ".", "crash_meta_test", "--crashes-dir", crashes.to_str().unwrap()
-    ]);
+    let output = run_crucible_in(
+        temp.path(),
+        &[
+            "show",
+            ".",
+            "crash_meta_test",
+            "--crashes-dir",
+            crashes.to_str().unwrap(),
+        ],
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("action_withdraw"), "should show action name, got: {}", stdout);
-    assert!(stdout.contains("99"), "should show iteration, got: {}", stdout);
+    assert!(
+        stdout.contains("action_withdraw"),
+        "should show action name, got: {}",
+        stdout
+    );
+    assert!(
+        stdout.contains("99"),
+        "should show iteration, got: {}",
+        stdout
+    );
 }
 
 #[test]
 fn test_run_replay_flag_exists() {
     ensure_cli_built();
     // Verify --replay is accepted (will fail because no harness, but shouldn't be "unknown flag")
-    let output = run_crucible_in(&std::env::temp_dir(), &["run", "test", "test", "--replay", "/nonexistent"]);
+    let output = run_crucible_in(
+        &std::env::temp_dir(),
+        &["run", "test", "test", "--replay", "/nonexistent"],
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!stderr.contains("unexpected argument"), "--replay should be a valid flag, got: {}", stderr);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "--replay should be a valid flag, got: {}",
+        stderr
+    );
 }
 
 #[test]
 fn test_run_crashes_out_flag_exists() {
     ensure_cli_built();
-    let output = run_crucible_in(&std::env::temp_dir(), &["run", "test", "test", "--crashes-out", "/tmp/crashes"]);
+    let output = run_crucible_in(
+        &std::env::temp_dir(),
+        &["run", "test", "test", "--crashes-out", "/tmp/crashes"],
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!stderr.contains("unexpected argument"), "--crashes-out should be a valid flag, got: {}", stderr);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "--crashes-out should be a valid flag, got: {}",
+        stderr
+    );
 }
 
 // =============================================================================
@@ -5378,9 +6430,9 @@ fn test_run_crashes_out_flag_exists() {
 #[test]
 fn test_fuzz_error_output() {
     // Verify [FUZZ_ERROR] strings exist in modes.rs source
-    let modes_src = std::fs::read_to_string(
-        project_root().join("crates/crucible-fuzz-macro/src/modes.rs")
-    ).unwrap();
+    let modes_src =
+        std::fs::read_to_string(project_root().join("crates/crucible-fuzz-macro/src/modes.rs"))
+            .unwrap();
     assert!(
         modes_src.contains("[FUZZ_ERROR]"),
         "modes.rs should contain [FUZZ_ERROR] output"
@@ -5390,9 +6442,9 @@ fn test_fuzz_error_output() {
 #[test]
 fn test_reproduces_false() {
     // Verify reproduces:false string exists in modes.rs source
-    let modes_src = std::fs::read_to_string(
-        project_root().join("crates/crucible-fuzz-macro/src/modes.rs")
-    ).unwrap();
+    let modes_src =
+        std::fs::read_to_string(project_root().join("crates/crucible-fuzz-macro/src/modes.rs"))
+            .unwrap();
     assert!(
         modes_src.contains("reproduces:false"),
         "modes.rs should contain reproduces:false output"
@@ -5402,17 +6454,37 @@ fn test_reproduces_false() {
 #[test]
 fn test_run_mode_flag_exists() {
     ensure_cli_built();
-    let output = run_crucible_in(&std::env::temp_dir(), &["run", "test", "test", "--mode", "explore"]);
+    let output = run_crucible_in(
+        &std::env::temp_dir(),
+        &["run", "test", "test", "--mode", "explore"],
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!stderr.contains("unexpected argument"), "--mode should be a valid flag, got: {}", stderr);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "--mode should be a valid flag, got: {}",
+        stderr
+    );
 }
 
 #[test]
 fn test_run_lcov_out_flag_exists() {
     ensure_cli_built();
-    let output = run_crucible_in(&std::env::temp_dir(), &["run", "test", "test", "--lcov-out", "./output/coverage.lcov"]);
+    let output = run_crucible_in(
+        &std::env::temp_dir(),
+        &[
+            "run",
+            "test",
+            "test",
+            "--lcov-out",
+            "./output/coverage.lcov",
+        ],
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!stderr.contains("unexpected argument"), "--lcov-out should be a valid flag, got: {}", stderr);
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "--lcov-out should be a valid flag, got: {}",
+        stderr
+    );
 }
 
 // =============================================================================
@@ -5424,15 +6496,21 @@ fn read_macro_src(filename: &str) -> String {
     let path = project_root()
         .join("crates/crucible-fuzz-macro/src")
         .join(filename);
-    fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
 }
 
 #[test]
 fn test_no_self_b_in_codegen() {
     // The feature/diff branch used hardcoded `self_b` references.
     // Multi-context generalization must have zero such references.
-    for file in &["lib.rs", "codegen.rs", "singlecore.rs", "multicore.rs", "stateful.rs", "modes.rs"] {
+    for file in &[
+        "lib.rs",
+        "codegen.rs",
+        "singlecore.rs",
+        "multicore.rs",
+        "stateful.rs",
+        "modes.rs",
+    ] {
         let src = read_macro_src(file);
         assert!(
             !src.contains("self_b"),
@@ -5463,11 +6541,7 @@ fn test_contexts_helpers_exist() {
     ];
 
     for h in normal_helpers.iter().chain(stateful_helpers.iter()) {
-        assert!(
-            src.contains(h),
-            "codegen.rs missing helper: {}",
-            h,
-        );
+        assert!(src.contains(h), "codegen.rs missing helper: {}", h,);
     }
 }
 
@@ -5485,14 +6559,16 @@ fn test_contexts_param_in_all_modes() {
     for (file, fn_sig) in cases {
         let src = read_macro_src(file);
         // Find the function signature and verify it contains `contexts:`
-        let fn_pos = src.find(fn_sig)
+        let fn_pos = src
+            .find(fn_sig)
             .unwrap_or_else(|| panic!("{} missing function: {}", file, fn_sig));
         // Look at the next ~500 chars for the closing paren of the signature
         let sig_region = &src[fn_pos..std::cmp::min(fn_pos + 500, src.len())];
         assert!(
             sig_region.contains("contexts:"),
             "{} function {} does not accept a `contexts` parameter",
-            file, fn_sig,
+            file,
+            fn_sig,
         );
     }
 }
@@ -5565,10 +6641,15 @@ fn test_fuzz_pulse_no_duplicate() {
         let src = read_macro_src(file);
         // Check there is no `println!(...FUZZ_PULSE...)` pattern
         for (i, line) in src.lines().enumerate() {
-            if line.contains("FUZZ_PULSE") && line.contains("println!") && !line.contains("eprintln!") {
+            if line.contains("FUZZ_PULSE")
+                && line.contains("println!")
+                && !line.contains("eprintln!")
+            {
                 panic!(
                     "{}:{} uses println! for FUZZ_PULSE (should use eprintln!): {}",
-                    file, i + 1, line.trim(),
+                    file,
+                    i + 1,
+                    line.trim(),
                 );
             }
         }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -3,10 +3,10 @@
 ## `crucible init`
 
 ```bash
-crucible init <program_name>
+crucible init <program_name> [-C <HARNESS_DIR>]
 ```
 
-Creates a standalone fuzz workspace in `fuzz/<program_name>/`.
+Creates a standalone fuzz workspace in `fuzz/<program_name>/` by default, or directly in `-C/--harness-dir`.
 
 ## `crucible run`
 
@@ -18,7 +18,7 @@ crucible run <program_name> <test_name> [OPTIONS]
 |------|-------------|
 | `--binary-in <PATH>` | Run a prebuilt harness binary directly |
 | `--release` | Build in release mode (recommended) |
-| `--coverage` | Enable LCOV coverage output |
+| `--coverage` | Enable coverage reporting |
 | `--timeout <SECS>` | Stop after N seconds |
 | `--cores N` / `-j N` | Run N parallel fuzzer workers |
 | `--corpus-in <DIR>` | Load seed corpus from directory |
@@ -30,9 +30,11 @@ crucible run <program_name> <test_name> [OPTIONS]
 | `--symbols <PATH>` | Path to debug binary with DWARF symbols (for source-level coverage) |
 | `--no-tracing` | Disable SVM register tracing (~2x faster, no coverage) |
 | `--stop-on-crash` | Stop fuzzing on first crash |
-| `--max-actions <N>` | Max actions per iteration (default: 10) |
+| `--max-actions <N>` | Max actions per iteration (default: 8 stateless, 100 stateful) |
 | `--stateful` | ItyFuzz-style stateful fuzzing: single action per iteration with state pool |
 | `--max-depth <N>` | Maximum state depth (action chain length) in stateful mode (default: 15) |
+| `--pool-size <N>` | State pool capacity in stateful mode (default: 256000) |
+| `--program-so <PATH>` | Override the program `.so` loaded by the harness |
 | `--mode <MODE>` | Remote fuzzing operational mode (see [Remote Fuzzing Integration](remote-fuzzing.md)) |
 | `--lcov-out <PATH>` | Custom LCOV coverage output file path |
 
@@ -43,7 +45,7 @@ crucible run <program_name> <test_name> [OPTIONS]
 crucible run myproject invariant_test --release --timeout 60
 
 # Run a prebuilt harness directly
-crucible run myproject invariant_test --binary-in ./fuzz/myproject/target/release/myproject_fuzz
+crucible run myproject invariant_test --binary-in ./fuzz/myproject/target/release/invariant_test
 
 # Multi-core fuzzing (4 workers)
 crucible run myproject invariant_test --release -j 4
@@ -53,6 +55,9 @@ crucible run myproject invariant_test --release --coverage --timeout 120
 
 # Coverage with custom output path
 crucible run myproject invariant_test --release --coverage --lcov-out ./output/coverage.lcov
+
+# Custom harness directory
+crucible run myproject invariant_test -C ./custom-harness --release
 
 # Dry-run validation
 crucible run myproject invariant_test --dry-run
@@ -81,6 +86,7 @@ crucible run myproject invariant_test --release --stateful --max-depth 20 -j 4
 
 ```bash
 crucible list <program_name>   # List tests for a program
+crucible list -C ./fuzz/myproject  # List tests from a harness dir
 crucible list                  # List all fuzz harnesses
 ```
 
@@ -96,6 +102,8 @@ crucible show . <crash_file>                               # Auto-detect from cu
 ```
 
 Use `"."` as the program name to auto-detect the fuzz harness when running from within the fuzz directory.
+
+`-C/--harness-dir` is a global option for locating a custom harness directory on `init`, `run`, `list`, `show`, `tmin`, and `cmin`.
 
 | Flag | Description |
 |------|-------------|

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -4,7 +4,7 @@ Crucible can generate LCOV coverage reports showing which lines of your Solana p
 
 ## Bytecode-level coverage
 
-Just add `--coverage` to your run command. This generates `coverage.lcov` using SBF program counter addresses as line numbers:
+Just add `--coverage` to your run command. This writes `./coverage/coverage.lcov` by default and uses SBF program counter addresses as line numbers:
 
 ```bash
 crucible run myproject invariant_test --release --coverage --timeout 60
@@ -76,7 +76,7 @@ You should see output like:
 
 ### Step 4: Generate HTML report
 
-The `coverage.lcov` file is written inside the fuzz harness target directory. Use `lcov` and `genhtml` to produce a browsable HTML report.
+By default the LCOV file is written to `./coverage/coverage.lcov` (or the path passed via `--lcov-out`). Use `lcov` and `genhtml` to produce a browsable HTML report.
 
 First, extract only your program's source files (filtering out stdlib and third-party crate paths):
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,8 @@
 crucible init <project_name>
 ```
 
+This creates `fuzz/<project_name>/` by default. Use `-C <dir>` to place the harness elsewhere.
+
 ### Run a fuzz test
 
 ```bash

--- a/docs/remote-fuzzing.md
+++ b/docs/remote-fuzzing.md
@@ -306,7 +306,7 @@ bundle/
 │       ├── Cargo.toml
 │       ├── src/main.rs                   # Harness code
 │       ├── idls/myproject.json           # Program IDL
-│       └── target/release/myproject_fuzz # Compiled harness binary
+│       └── target/release/invariant_test # Compiled harness binary
 ├── target/
 │   └── deploy/myproject.so              # Program binary (loaded by harness)
 ├── programs/
@@ -375,7 +375,7 @@ When running under a remote driver (`--mode` set), Crucible behaves slightly dif
 |----------|-----------|----------|
 | Corpus directory | User-specified or `fuzz/<prog>/corpus/` | `./corpus` (CWD-relative) |
 | Crash directory | `fuzz/<prog>/crashes/<test>/` | `./output` |
-| Coverage output | `coverage.lcov` in fuzz target dir | `./output/coverage.lcov` |
+| Coverage output | `./coverage/coverage.lcov` | `./output/coverage.lcov` |
 | Stop-on-crash | Off by default | Always on in `explore` |
 | Account diffs on replay | Auto-enabled | Auto-enabled |
 

--- a/examples/anchor-counter/fuzz/counter/Cargo.toml
+++ b/examples/anchor-counter/fuzz/counter/Cargo.toml
@@ -18,5 +18,9 @@ solana-keypair = "3.0"
 solana-pubkey = "3.0"
 solana-signer = "3.0"
 
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
+
 [features]
 invariant_counter = []

--- a/examples/klend/fuzz/klend/Cargo.toml
+++ b/examples/klend/fuzz/klend/Cargo.toml
@@ -29,6 +29,10 @@ ctrlc = "3.4"
 ctor = "0.6"
 litesvm = { version = "0.9.0", features = ["register-tracing"] }
 
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
+
 [features]
 fuzz_single = []
 invariant_test = []

--- a/examples/marginfi-v2-fuzz/fuzz/marginfi-v2-fuzz/Cargo.lock
+++ b/examples/marginfi-v2-fuzz/fuzz/marginfi-v2-fuzz/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "solana-bpf-loader-program",
  "solana-compute-budget",
  "solana-hash 3.1.0",
+ "solana-instruction",
  "solana-keypair",
  "solana-message",
  "solana-program-runtime",

--- a/examples/marginfi-v2-fuzz/fuzz/marginfi-v2-fuzz/Cargo.toml
+++ b/examples/marginfi-v2-fuzz/fuzz/marginfi-v2-fuzz/Cargo.toml
@@ -36,6 +36,10 @@ litesvm = { version = "0.9.0", features = ["register-tracing"] }
 ctrlc = "3.4"
 serde_json = "1.0"
 
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
+
 [features]
 fuzz_single = []
 invariant_test = []

--- a/examples/staking/fuzz/staking/Cargo.toml
+++ b/examples/staking/fuzz/staking/Cargo.toml
@@ -21,6 +21,10 @@ staking = { path = "../../programs/staking", features = ["no-entrypoint"] }
 ctrlc = "3.4"
 serde_json = "1.0"
 
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
+
 [features]
 fuzz_staking = []
 invariant_fuzz = []

--- a/examples/whirlpools/fuzz/whirlpool/Cargo.toml
+++ b/examples/whirlpools/fuzz/whirlpool/Cargo.toml
@@ -38,6 +38,10 @@ ctrlc = "3.4"
 spl-token = "9.0"
 spl-associated-token-account = "7.0"
 
+[[bin]]
+name = "invariant_test"
+path = "src/main.rs"
+
 [features]
 fuzz_single = []
 invariant_test = []


### PR DESCRIPTION
- Changes fuzz_dir option to harness_dir and make use of it more consistent
- Make harness binary naming fixed and remove dynamic search for the binary name
- harness binary can still be supplied manually
- Run cargo fmt on entire cli crate
- Fix cli tests
- Split up cli into `main.rs` and `templates.rs` files