### PR TITLE
Add proper usage of 'None' on calling harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crucible-macro-utils",
  "proc-macro2",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libafl",
  "libafl_bolts",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzzer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-idl-gen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang-idl",
  "anyhow",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-invariant-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crucible-macro-utils",
  "proc-macro2",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-macro-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-test-context"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "addr2line 0.24.2",
  "anchor-lang",

--- a/crates/crucible-idl-gen/src/codegen/accounts.rs
+++ b/crates/crucible-idl-gen/src/codegen/accounts.rs
@@ -145,6 +145,16 @@ pub fn generate(idl: &Idl) -> proc_macro2::TokenStream {
                                 is_writable: #is_writable,
                             });
                         }
+
+                        // If it's an optional type that is not included, then provide the PROGRAM ID as the account key. 
+                        // https://github.com/otter-sec/anchor/blob/4ca8e91a24c543bdd122f01f39b575bbd6f16cc3/lang/syn/src/codegen/accounts/to_account_metas.rs#L29
+                        else {
+                            account_metas.push(AccountMeta {
+                                pubkey: ID,
+                                is_signer: false,
+                                is_writable: false,
+                            });
+                        }
                     }
                 } else {
                     quote! {
@@ -930,12 +940,22 @@ mod tests {
         let meta_body = &generated[meta_fn_start..];
         let pushes: Vec<&str> = meta_body.split("account_metas . push").skip(1).collect();
 
-        // plain, vault, optional_reserve (if-let), rent (fixed) = 4 pushes
+        // plain, vault, optional_reserve (if-let Some + else placeholder),
+        // rent (fixed) = 5 push *statements* in the generated source. The
+        // optional account emits two pushes (only one fires at runtime).
         assert_eq!(
             pushes.len(),
-            4,
-            "should have 4 account pushes, got {}",
+            5,
+            "should have 5 account push statements, got {}",
             pushes.len()
+        );
+
+        // optional_reserve's `else` arm (index 3) should fall back to the
+        // program ID as a non-signer, non-writable placeholder.
+        assert!(
+            pushes[3].contains("pubkey : ID"),
+            "absent optional account should use program ID placeholder, got: {}",
+            pushes[3]
         );
 
         // vault (index 1) should be writable, not signer


### PR DESCRIPTION
The 'None' optional was just ignoring the account when it wasn't provided. Since the program still expected an account, this was a problem.

Anchor expects the programs own ID to be used in case of 'None'. So, this adds a patch to do that.