### PR TITLE
fix(multicore): pin workers to actually-schedulable cores, not raw 0..N

### DIFF
--- a/crates/crucible-fuzz-macro/src/multicore.rs
+++ b/crates/crucible-fuzz-macro/src/multicore.rs
@@ -58,7 +58,7 @@ pub fn multicore_mode(
             // Uses LibAFL Launcher with fork() and LLMP for parallel fuzzing
             use std::collections::HashSet;
             use libafl_bolts::shmem::{ShMem, ShMemProvider, StdShMemProvider};
-            use libafl_bolts::core_affinity::Cores;
+            use libafl_bolts::core_affinity::{Cores, get_core_ids};
             use libafl::events::{EventConfig, Launcher, ClientDescription};
             use libafl::monitors::MultiMonitor;
             use libafl::Error as LibAflError;
@@ -799,7 +799,26 @@ pub fn multicore_mode(
             };
 
             // Build and launch the multi-core fuzzer
-            let cores = Cores::from((0..num_cores).collect::<Vec<_>>());
+            //
+            // Pin to cores this process can actually be scheduled on (respects
+            // sched_getaffinity / cgroup cpuset), not raw host CPU indices 0..N.
+            // Hardcoding 0..N here means every concurrent instance of the harness
+            // on a shared host (e.g. multiple containers with a CPU quota/shares
+            // limit but no cpuset) picks the identical physical cores, turning
+            // "N cores each" into severe cross-instance contention instead of
+            // parallelism. Querying available cores makes this a no-op wherever
+            // the process is unconstrained (the common case), and correct
+            // wherever it's cpuset-restricted.
+            let available_cores = get_core_ids()
+                .unwrap_or_else(|e| panic!("[FUZZ] Failed to query available CPU cores: {}", e));
+            if available_cores.len() < num_cores {
+                eprintln!(
+                    "[FUZZ] Warning: FUZZ_CORES={} requested but only {} core(s) are schedulable; using {}.",
+                    num_cores, available_cores.len(), available_cores.len()
+                );
+            }
+            let selected: Vec<usize> = available_cores.into_iter().take(num_cores).map(|c| c.0).collect();
+            let cores = Cores::from(selected);
 
             // Set up panic hook for Launcher to suppress expected shutdown panics
             let default_hook = std::panic::take_hook();


### PR DESCRIPTION
## Summary
`Cores::from((0..num_cores).collect())` in the multicore launcher assumes host CPU indices `0..N-1` are available and uncontended. Under any container/cgroup setup that limits CPU via quota+shares but not `cpuset` (a common configuration for containerized CI/build systems), sched_getaffinity still reports the full host core list. That means every concurrent instance of a crucible harness on the same host independently computes the same "available" cores and pins its workers to the identical physical CPUs, turning "N cores per instance" into contention instead of parallelism whenever more than one instance runs at a time.

## Fix
Query `get_core_ids()` (sched_getaffinity) and take the first `num_cores` of what's actually reported, instead of assuming `0..N`. This is a no-op wherever the process is unconstrained (get_core_ids() already returns `[0, 1, ..., N-1]` in that case — the common local-dev/CI scenario), and correct wherever the process is cpuset-restricted.

## Reproduction
Ran two containers concurrently, each requesting `FUZZ_CORES=2` on a host with idle cores to spare (no reason for real contention). Aggregate throughput showed no scaling compared to running a single container, and `taskset -pc` on the worker PIDs in both containers confirmed identical CPU affinity masks — both pinned to the same physical cores.