### PR TITLE
coverage: don't infer source root from FUZZ_SYMBOLS path

### DIFF
--- a/crates/crucible-test-context/src/coverage/dwarf.rs
+++ b/crates/crucible-test-context/src/coverage/dwarf.rs
@@ -12,6 +12,18 @@ pub struct SourceLocation {
     pub line: u32,
 }
 
+/// Optional on-disk root for resolving relative DWARF file paths, read from the
+/// explicit `FUZZ_SOURCE_ROOT` env var.
+///
+/// This is intentionally explicit. It must NOT be inferred from `FUZZ_SYMBOLS`
+/// (which the earlier implementation did by splitting at "/target/"): a symbols
+/// binary staged under any `.../target/...` path — e.g. a fuzzcorp bundle at
+/// `<bundle>/target/deploy/prog.debug.so` — would yield the wrong root and corrupt
+/// source-path resolution, producing an LCOV with zero resolvable source files.
+fn coverage_source_root() -> Option<String> {
+    std::env::var("FUZZ_SOURCE_ROOT").ok()
+}
+
 /// Pre-computed PC-to-source mapping, built once from a debug binary.
 ///
 /// All PCs are eagerly resolved at init time to avoid lifetime issues
@@ -68,11 +80,21 @@ pub fn build_dwarf_source_map(debug_binary: &[u8]) -> Option<DwarfSourceMap> {
     let dwarf = gimli::Dwarf::load(&load_section).ok()?;
     let context = addr2line::Context::from_dwarf(dwarf).ok()?;
 
-    // Infer workspace root from FUZZ_SYMBOLS for resolving relative DWARF paths.
-    // e.g. "/home/user/project/target/sbpf-.../release/prog.so" → "/home/user/project"
-    let source_root: Option<String> = std::env::var("FUZZ_SYMBOLS")
-        .ok()
-        .and_then(|p| p.find("/target/").map(|idx| p[..idx].to_string()));
+    // Optional source root for resolving relative DWARF paths to on-disk files.
+    // This is a convenience for the local `crucible run --coverage` + genhtml flow,
+    // opt-in via the FUZZ_SOURCE_ROOT env var.
+    //
+    // It is deliberately NOT inferred from the FUZZ_SYMBOLS path. The previous code
+    // derived it by splitting FUZZ_SYMBOLS at "/target/", which is a latent trap:
+    // whenever the symbols binary is staged under any ".../target/..." path (e.g. a
+    // fuzzcorp bundle at `<bundle>/target/deploy/prog.debug.so`), the split yields
+    // the bundle root instead of the build workspace and corrupts path resolution —
+    // producing an LCOV with zero resolvable source files even though the DWARF is
+    // fully intact (which then fails the downstream lcov→fcov conversion). The
+    // emitted path must depend only on the DWARF contents, never on where the
+    // symbols file happens to sit; consumers remap the build prefix to wherever the
+    // sources are actually staged.
+    let source_root = coverage_source_root();
 
     // Resolve a DWARF file path to an absolute path.
     // Tries canonicalize first (works if CWD matches), then prepends source_root.
@@ -229,4 +251,29 @@ pub fn build_dwarf_source_map(debug_binary: &[u8]) -> Option<DwarfSourceMap> {
         fn_map,
         executable_lines,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::coverage_source_root;
+
+    /// Regression: the coverage source root must come only from the explicit
+    /// FUZZ_SOURCE_ROOT env var, never inferred from FUZZ_SYMBOLS. Inferring it by
+    /// splitting FUZZ_SYMBOLS at "/target/" corrupted source-path resolution whenever
+    /// the symbols binary was staged under a ".../target/..." path (e.g. a bundle),
+    /// yielding an LCOV with zero resolvable source files.
+    #[test]
+    fn source_root_is_explicit_not_inferred_from_symbols() {
+        // A FUZZ_SYMBOLS path under ".../target/..." must have no effect.
+        std::env::remove_var("FUZZ_SOURCE_ROOT");
+        std::env::set_var("FUZZ_SYMBOLS", "/some/bundle/target/deploy/prog.debug.so");
+        assert_eq!(coverage_source_root(), None);
+
+        // Only the explicit env var is honored.
+        std::env::set_var("FUZZ_SOURCE_ROOT", "/explicit/root");
+        assert_eq!(coverage_source_root(), Some("/explicit/root".to_string()));
+
+        std::env::remove_var("FUZZ_SOURCE_ROOT");
+        std::env::remove_var("FUZZ_SYMBOLS");
+    }
 }


### PR DESCRIPTION
## Problem

`build_dwarf_source_map` (`crates/crucible-test-context/src/coverage/dwarf.rs`) infers the workspace root by splitting `FUZZ_SYMBOLS` at `"/target/"`:

```rust
let source_root = std::env::var("FUZZ_SYMBOLS")
    .ok()
    .and_then(|p| p.find("/target/").map(|idx| p[..idx].to_string()));
```

This assumes the symbols binary always lives at `<workspace>/target/.../prog.so`. It breaks the moment the symbols binary is staged **anywhere under a `.../target/...` path** — which is exactly what a remote-fuzzing bundle does. When the debug binary is staged at `<bundle>/target/deploy/prog.debug.so`, the split yields the **bundle root** instead of the build workspace, corrupting source-path resolution.

The symptom is subtle because the DWARF is completely intact: `[COVERAGE] DWARF source map loaded: N PCs resolved`, but then `[LCOV] Source-level coverage: 0 source files`. The LCOV comes out PC-keyed (`SF:program_<hash>.bpf`), and the downstream lcov→fcov conversion then hard-fails because `SourcesOriginalPath` matches no source file in the profile.

### How it was isolated

Same debug binary (byte-identical, verified via md5), same container, same corpus, back to back — the only difference being the `FUZZ_SYMBOLS` **path**:

| `FUZZ_SYMBOLS` | result |
| --- | --- |
| `<bundle>/target/deploy/prog.debug.so` | **0 source files** |
| `/prog.debug.so` (same bytes, no `/target/`) | full source-level mapping |

Identical input, different output based purely on where the file sits — the `/target/` split is the only path-dependent code, so that inference is the culprit.

## Fix

Read the source root from an explicit `FUZZ_SOURCE_ROOT` env var instead of inferring it from the symbols path. The emitted source paths now depend only on the DWARF contents, never on where the symbols binary happens to be staged; consumers (e.g. an lcov→fcov remap) map the build prefix to wherever the sources actually live.

- Local `crucible run --coverage` still resolves on-disk paths via the existing `canonicalize(file)` first-try (the binary is built on the same machine), so genhtml is unaffected for the common case. Anyone relying on relative-path resolution can set `FUZZ_SOURCE_ROOT` explicitly.
- Added a regression test pinning the contract that `FUZZ_SYMBOLS` no longer influences the source root.

Verified end-to-end: with the symbols binary staged off a `/target/` path, coverage emits real source-level `SF:` entries and the lcov→fcov conversion succeeds.

## Follow-up suggestion

The repo has no DWARF-carrying coverage fixture (`test-data/staking.so` is stripped), so a full integration test of `build_dwarf_source_map` isn't possible here. Adding a small unstripped fixture would let a test assert that emitted `SF:` paths are identical regardless of `FUZZ_SYMBOLS`. Happy to follow up if a fixture is available.