### PR TITLE
Pin generated harness deps to the CLI version; publish releases from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches workspace version
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "crucible-fuzz-cli") | .version')
+          if [ "v$version" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match workspace version $version" >&2
+            exit 1
+          fi
+
+      # Generated harnesses depend on the crates.io release matching the CLI
+      # version, so every crate must be published for a release to be usable.
+      # Order follows the internal dependency graph; `cargo publish` waits for
+      # each crate to appear in the index before returning, and already-published
+      # crates are skipped so a failed run can be retried by re-running the job.
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "crucible-fuzz-cli") | .version')
+          for crate in \
+            crucible-macro-utils \
+            crucible-test-context \
+            crucible-idl-gen \
+            crucible-fuzz-runtime \
+            crucible-fuzz-cli \
+            crucible-invariant-macro \
+            crucible-fuzz-macro \
+            crucible-fuzzer; do
+            if curl -fsSL -A "crucible-release-workflow" "https://crates.io/api/v1/crates/$crate/$version" | jq -e '.version' > /dev/null 2>&1; then
+              echo "$crate $version already published, skipping"
+              continue
+            fi
+            cargo publish -p "$crate"
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-macro"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crucible-macro-utils",
  "proc-macro2",
@@ -1301,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzz-runtime"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libafl",
  "libafl_bolts",
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-fuzzer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-idl-gen"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anchor-lang-idl",
  "anyhow",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-invariant-macro"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crucible-macro-utils",
  "proc-macro2",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-macro-utils"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "crucible-test-context"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "addr2line 0.24.2",
  "anchor-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 

--- a/crates/crucible-fuzz-cli/src/templates.rs
+++ b/crates/crucible-fuzz-cli/src/templates.rs
@@ -1,6 +1,7 @@
 pub fn generate_cargo_toml(program_name: &str) -> String {
-    let repo = "https://github.com/asymmetric-research/crucible";
-    let branch = "main";
+    // Pin the harness to the same crucible version as the CLI that generated it,
+    // so pushes to main can't break generated or existing harnesses.
+    let version = env!("CARGO_PKG_VERSION");
 
     format!(
         r#"[package]
@@ -13,9 +14,9 @@ edition = "2021"
 
 [dependencies]
 # Fuzzing framework
-crucible-fuzzer = {{ git = "{repo}", branch = "{branch}" }}
-crucible-test-context = {{ git = "{repo}", branch = "{branch}" }}
-crucible-idl-gen = {{ git = "{repo}", branch = "{branch}" }}
+crucible-fuzzer = "{version}"
+crucible-test-context = "{version}"
+crucible-idl-gen = "{version}"
 
 anchor-lang = "1.0.1"
 

--- a/crates/crucible-fuzz-macro/Cargo.toml
+++ b/crates/crucible-fuzz-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-fuzz-macro"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license.workspace = true
 description = "Fuzzing macros for crucible-fuzzer"
@@ -12,4 +12,4 @@ proc-macro = true
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-crucible-macro-utils = { path = "../crucible-macro-utils", version = "0.2.0" }
+crucible-macro-utils = { path = "../crucible-macro-utils", version = "0.2.1" }

--- a/crates/crucible-fuzz-runtime/Cargo.toml
+++ b/crates/crucible-fuzz-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-fuzz-runtime"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license.workspace = true
 description = "Runtime support for structured fuzzing with crucible-fuzzer"

--- a/crates/crucible-fuzzer/Cargo.toml
+++ b/crates/crucible-fuzzer/Cargo.toml
@@ -8,10 +8,10 @@ description = "Solana smart contract fuzzing framework"
 [dependencies]
 rand = "0.8"
 anyhow = { workspace = true }
-crucible-test-context = { path = "../crucible-test-context", version = "0.2.0" }
-crucible-fuzz-macro = { path = "../crucible-fuzz-macro", version = "0.2.0" }
-crucible-invariant-macro = { path = "../crucible-invariant-macro", version = "0.2.0" }
-crucible-fuzz-runtime = { path = "../crucible-fuzz-runtime", version = "0.2.0" }
+crucible-test-context = { path = "../crucible-test-context", version = "0.2.1" }
+crucible-fuzz-macro = { path = "../crucible-fuzz-macro", version = "0.2.1" }
+crucible-invariant-macro = { path = "../crucible-invariant-macro", version = "0.2.1" }
+crucible-fuzz-runtime = { path = "../crucible-fuzz-runtime", version = "0.2.1" }
 anchor-lang = { workspace = true }
 anchor-spl = { workspace = true }
 mimalloc = { version = "0.1", default-features = false }

--- a/crates/crucible-idl-gen/Cargo.toml
+++ b/crates/crucible-idl-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-idl-gen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license.workspace = true
 description = "Generate Rust types from Anchor IDL for fuzzing"

--- a/crates/crucible-invariant-macro/Cargo.toml
+++ b/crates/crucible-invariant-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-invariant-macro"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license.workspace = true
 description = "Invariant-test attribute macro for crucible-fuzzer"
@@ -9,7 +9,7 @@ description = "Invariant-test attribute macro for crucible-fuzzer"
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-crucible-macro-utils = { path = "../crucible-macro-utils", version = "0.2.0" }
+crucible-macro-utils = { path = "../crucible-macro-utils", version = "0.2.1" }
 
 [lib]
 proc-macro = true

--- a/crates/crucible-macro-utils/Cargo.toml
+++ b/crates/crucible-macro-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-macro-utils"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license.workspace = true
 description = "Shared utilities for crucible-fuzzer proc-macros"

--- a/crates/crucible-test-context/Cargo.toml
+++ b/crates/crucible-test-context/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crucible-test-context"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license.workspace = true
 description = "LiteSVM-backed test context used by crucible-fuzzer"


### PR DESCRIPTION
## Problem

`anchor fuzz init` generates a Cargo.toml whose crucible deps are `{ git = "...", branch = "main" }` — unpinned, no version or rev. Every push to `main` instantly becomes what new harnesses build against, and existing harnesses break later on `cargo update` or lockfile-less CI builds, far from the commit that caused it. In effect, any push to `main` is a release.

## Changes

- **`fix(cli)`**: the generated Cargo.toml now pins `crucible-fuzzer` / `crucible-test-context` / `crucible-idl-gen` to the crates.io release matching the CLI's own version (`env!("CARGO_PKG_VERSION")`), so a harness always builds against the same crucible that the CLI generating it shipped with.
- **`ci`**: new `release.yml` — pushing a `v*` tag verifies the tag matches the workspace version, then publishes all 8 workspace crates to crates.io in dependency order. Already-published crates are skipped, so a failed run is retryable. This guards the invariant the pin fix introduces: a version bump is only usable once every crate is published.
- **`bump`**: 0.2.0 → 0.2.1 (workspace version, per-crate versions, internal dep pins, lockfile).

## Release/rollout

1. Merge — safe for existing harnesses: the template change only affects new `init`s, and 0.2.1 has no API changes for harnesses still tracking `branch = "main"`.
2. `git tag v0.2.1 && git push origin v0.2.1` — CI publishes the crates (`CARGO_REGISTRY_TOKEN` secret is already set).
3. Follow-up PR to otter-sec/anchor: `cargo update -p crucible-fuzz-cli` (lockfile-only; anchor's `"0.2.0"` caret req accepts 0.2.1).